### PR TITLE
[Docs] Improve ai_agent setup instructions and add set_llm Mimo subscription API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,16 @@
 
 ## 快速开始
 
-### 编译
-
 前提条件：下载 openvela 源码
+- dev 分支：ai_agent 包可以通过 repo sync 自动获取；
+- trunk 分支：默认不包含 ai_agent，需手动引入 packages_ai_agent 仓库。
+
+对于 trunk 分支，请进入 openvela 根目录，执行以下命令，将该仓库克隆到正确路径：
+```bash
+git clone https://github.com/open-vela/packages_ai_agent.git packages/ai_agent
+```
+
+### 编译
 
 ```bash
 # 打开 menuconfig 启用 AI Agent
@@ -49,6 +56,13 @@ vela> mcp_add amap https://mcp.amap.com/mcp?key=xxx  # 接入高德地图 MCP
 vela> mcp_add didi https://mcp.didichuxing.com/mcp-servers?key=xxx  # 接入滴滴出行 MCP
 vela> mcp_discover                       # 发现远程工具
 ```
+
+### 使用 Mimo 订阅制 API（tp-）
+对于小米 Mimo 的订阅制 API（tp-），需要手动指定 Base URL 和模型名称。可以通过以下方式直接在 NSH 中配置：
+```bash
+vela> set_llm token-plan-cn.xiaomimimo.com mimo-v2-omni tp-xxxxxxxxxx   # 设置mimo-v2-omni
+```
+
 
 ## 支持的 LLM 后端
 


### PR DESCRIPTION
# Updated README.md
…subscription API example

This PR includes two documentation improvements:

1. Clarify ai_agent availability across branches  
   - Added a note that the `ai_agent` package is automatically available via `repo sync` in the `dev` branch.  
   - Clarified that the `trunk` branch does not include it by default, and requires manual cloning of the `packages_ai_agent` repository.

2. Add example for using Mimo subscription-based API (tp-)  
   - Added a usage example for switching to the Mimo subscription-based API via `set_llm`.  
   - Clarify the required Base URL for using Mimo (tp-).

```bash
vela> set_llm token-plan-cn.xiaomimimo.com mimo-v2-omni tp-xxxxxxxxxx   # 设置mimo-v2-omni
```
The actual usage result is shown below.
<img width="747" height="732" alt="18" src="https://github.com/user-attachments/assets/820acc19-b6d0-4b6a-a021-4a059bf00d87" />


These changes aim to improve usability and reduce confusion during setup and LLM configuration.