### PR TITLE
refactor: extract shared url_parse for http/https/ws/wss

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(CONFIG_EXAMPLES_AI_AGENT_VELA)
     src/infra/vela_tls.c
     src/infra/config_store.c
     src/infra/network_manager.c
+    src/infra/url_parse.c
     src/infra/cron_service.c
     src/infra/heartbeat.c
     src/channels/nsh_commands.c

--- a/src/channels/cmd_llm.c
+++ b/src/channels/cmd_llm.c
@@ -16,6 +16,7 @@
 
 #include "channels/cmd_llm.h"
 #include "infra/config_store.h"
+#include "infra/url_parse.h"
 #include "llm/llm_proxy.h"
 #include "llm/llm_router.h"
 #include "infra/http_proxy.h"
@@ -87,56 +88,20 @@ void cmd_set_llm(int argc, char** argv)
     const char* model = NULL;
     const char* api_key = NULL;
     int cost_tier = 1;
-    static char parsed_host[128];
 
     /* Check if arg1 is a URL (http:// or https://) */
     if (strncmp(arg1, "http://", 7) == 0 || strncmp(arg1, "https://", 8) == 0) {
-        /* Parse URL: scheme://host[:port][/path] */
-        int is_https = (strncmp(arg1, "https://", 8) == 0);
-        const char* after_scheme = arg1 + (is_https ? 8 : 7);
-        port = is_https ? "443" : "80";
-
-        /* Find host end (first '/' or ':' or end) */
-        const char* slash = strchr(after_scheme, '/');
-        const char* colon = strchr(after_scheme, ':');
-
-        if (colon && (!slash || colon < slash)) {
-            /* host:port/path */
-            size_t hlen = (size_t)(colon - after_scheme);
-            if (hlen >= sizeof(parsed_host))
-                hlen = sizeof(parsed_host) - 1;
-            memcpy(parsed_host, after_scheme, hlen);
-            parsed_host[hlen] = '\0';
-            host = parsed_host;
-
-            /* Extract port */
-            static char parsed_port[8];
-            const char* port_start = colon + 1;
-            const char* port_end = slash ? slash : port_start + strlen(port_start);
-            size_t plen = (size_t)(port_end - port_start);
-            if (plen >= sizeof(parsed_port))
-                plen = sizeof(parsed_port) - 1;
-            memcpy(parsed_port, port_start, plen);
-            parsed_port[plen] = '\0';
-            port = parsed_port;
-        } else if (slash) {
-            /* host/path (no port) */
-            size_t hlen = (size_t)(slash - after_scheme);
-            if (hlen >= sizeof(parsed_host))
-                hlen = sizeof(parsed_host) - 1;
-            memcpy(parsed_host, after_scheme, hlen);
-            parsed_host[hlen] = '\0';
-            host = parsed_host;
-        } else {
-            /* host only */
-            strncpy(parsed_host, after_scheme, sizeof(parsed_host) - 1);
-            parsed_host[sizeof(parsed_host) - 1] = '\0';
-            host = parsed_host;
+        static parsed_url_t parsed;
+        if (url_parse(arg1, &parsed) != 0) {
+            printf("Invalid URL: %s\n", arg1);
+            return;
         }
+        host = parsed.host;
+        port = parsed.port;
 
         /* Extract path from URL */
-        if (slash && slash[1]) {
-            path = slash;
+        if (parsed.path[0] && parsed.path[1]) {
+            path = parsed.path;
         } else {
             path = "/v1/chat/completions";
         }

--- a/src/channels/feishu_http.c
+++ b/src/channels/feishu_http.c
@@ -17,6 +17,7 @@
 #include "channels/feishu_internal.h"
 #include "infra/config_store.h"
 #include "infra/http_proxy.h"
+#include "infra/url_parse.h"
 #include "infra/vela_tls.h"
 #include "cJSON.h"
 
@@ -373,32 +374,17 @@ int feishu_create_connection(char* ws_host, size_t host_cap,
 
     syslog(LOG_INFO, "[%s] Got WS URL: %s\n", TAG, ws_url);
 
-    /* Skip "wss://" prefix */
-    const char* p = ws_url;
-
-    if (strncmp(p, "wss://", 6) == 0) {
-        p += 6;
-    } else if (strncmp(p, "ws://", 5) == 0) {
-        p += 5;
+    parsed_url_t parsed;
+    if (url_parse(ws_url, &parsed) != 0) {
+        syslog(LOG_ERR, "[%s] Invalid WS URL: %s\n", TAG, ws_url);
+        cJSON_Delete(root);
+        return ERROR;
     }
 
-    /* Extract host and path */
-    const char* slash = strchr(p, '/');
-
-    if (slash) {
-        size_t hlen = (size_t)(slash - p);
-        if (hlen >= host_cap) {
-            hlen = host_cap - 1;
-        }
-        memcpy(ws_host, p, hlen);
-        ws_host[hlen] = '\0';
-        strncpy(ws_path, slash, path_cap - 1);
-        ws_path[path_cap - 1] = '\0';
-    } else {
-        strncpy(ws_host, p, host_cap - 1);
-        ws_host[host_cap - 1] = '\0';
-        strncpy(ws_path, "/", path_cap - 1);
-    }
+    strncpy(ws_host, parsed.host, host_cap - 1);
+    ws_host[host_cap - 1] = '\0';
+    strncpy(ws_path, parsed.path, path_cap - 1);
+    ws_path[path_cap - 1] = '\0';
 
     cJSON_Delete(root);
 

--- a/src/channels/weixin_channel.c
+++ b/src/channels/weixin_channel.c
@@ -40,6 +40,7 @@
 #include "core/message_bus.h"
 #include "cJSON.h"
 #include "infra/config_store.h"
+#include "infra/url_parse.h"
 #include "infra/vela_tls.h"
 #include "agent_compat.h"
 #include "agent_config.h"
@@ -675,15 +676,15 @@ int weixin_channel_poll_login(const char* qrcode_id)
 
         if (cJSON_IsString(base_j) && base_j->valuestring[0]) {
             /* Parse host from baseurl (https://host) */
-            const char* url = base_j->valuestring;
-            if (strncmp(url, "https://", 8) == 0)
-                url += 8;
-            strncpy(s_host, url, sizeof(s_host) - 1);
-            s_host[sizeof(s_host) - 1] = '\0';
-            /* Remove trailing slash */
-            size_t len = strlen(s_host);
-            if (len > 0 && s_host[len - 1] == '/')
-                s_host[len - 1] = '\0';
+            parsed_url_t parsed;
+            if (url_parse(base_j->valuestring, &parsed) == 0) {
+                strncpy(s_host, parsed.host, sizeof(s_host) - 1);
+                s_host[sizeof(s_host) - 1] = '\0';
+            } else {
+                /* Fallback: use raw value */
+                strncpy(s_host, base_j->valuestring, sizeof(s_host) - 1);
+                s_host[sizeof(s_host) - 1] = '\0';
+            }
             claw_config_set("weixin.host", s_host);
         }
 

--- a/src/infra/url_parse.c
+++ b/src/infra/url_parse.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "infra/url_parse.h"
+
+#include <string.h>
+
+int url_parse(const char *url, parsed_url_t *out)
+{
+    if (!url || !out)
+        return -1;
+
+    memset(out, 0, sizeof(*out));
+
+    /* Strip scheme and set defaults */
+    if (strncmp(url, "https://", 8) == 0) {
+        out->use_tls = true;
+        url += 8;
+        strncpy(out->port, "443", sizeof(out->port) - 1);
+    } else if (strncmp(url, "http://", 7) == 0) {
+        out->use_tls = false;
+        url += 7;
+        strncpy(out->port, "80", sizeof(out->port) - 1);
+    } else if (strncmp(url, "wss://", 6) == 0) {
+        out->use_tls = true;
+        url += 6;
+        strncpy(out->port, "443", sizeof(out->port) - 1);
+    } else if (strncmp(url, "ws://", 5) == 0) {
+        out->use_tls = false;
+        url += 5;
+        strncpy(out->port, "80", sizeof(out->port) - 1);
+    } else {
+        return -1;
+    }
+
+    const char *slash = strchr(url, '/');
+    const char *colon = strchr(url, ':');
+
+    /* Extract host and optional port */
+    if (colon && (!slash || colon < slash)) {
+        size_t hlen = (size_t)(colon - url);
+        if (hlen >= sizeof(out->host))
+            hlen = sizeof(out->host) - 1;
+        memcpy(out->host, url, hlen);
+        out->host[hlen] = '\0';
+
+        colon++;
+        const char *pend = slash ? slash : colon + strlen(colon);
+        size_t plen = (size_t)(pend - colon);
+        if (plen >= sizeof(out->port))
+            plen = sizeof(out->port) - 1;
+        memcpy(out->port, colon, plen);
+        out->port[plen] = '\0';
+    } else {
+        size_t hlen = slash ? (size_t)(slash - url) : strlen(url);
+        if (hlen >= sizeof(out->host))
+            hlen = sizeof(out->host) - 1;
+        memcpy(out->host, url, hlen);
+        out->host[hlen] = '\0';
+    }
+
+    /* Extract path */
+    if (slash) {
+        strncpy(out->path, slash, sizeof(out->path) - 1);
+        out->path[sizeof(out->path) - 1] = '\0';
+    } else {
+        strncpy(out->path, "/", sizeof(out->path) - 1);
+    }
+
+    /* Reject empty host */
+    if (out->host[0] == '\0')
+        return -1;
+
+    return 0;
+}

--- a/src/infra/url_parse.h
+++ b/src/infra/url_parse.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __URL_PARSE_H__
+#define __URL_PARSE_H__
+
+#include <stdbool.h>
+
+/**
+ * url_parse.h — Shared URL parser for http(s) and ws(s) schemes.
+ *
+ * Supports: http:// https:// ws:// wss://
+ * Extracts: host, port, path, use_tls flag.
+ */
+
+typedef struct {
+    char host[128];
+    char port[8];
+    char path[256];
+    bool use_tls;
+} parsed_url_t;
+
+/**
+ * Parse a URL into host, port, path components.
+ *
+ * @param url   Full URL (e.g. "https://host:443/path")
+ * @param out   Parsed result
+ * @return 0 on success, -1 on unsupported scheme
+ */
+int url_parse(const char *url, parsed_url_t *out);
+
+#endif /* __URL_PARSE_H__ */

--- a/src/tools/mcp_client.c
+++ b/src/tools/mcp_client.c
@@ -26,66 +26,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "infra/url_parse.h"
+
 static const char* TAG = "mcp_client";
-
-/* ── URL parsing helper ─────────────────────────────────── */
-
-typedef struct {
-    char host[128];
-    char port[8];
-    char path[128];
-    bool use_tls;
-} parsed_url_t;
-
-static int parse_url(const char* url, parsed_url_t* out)
-{
-    memset(out, 0, sizeof(*out));
-
-    if (strncmp(url, "https://", 8) == 0) {
-        out->use_tls = true;
-        url += 8;
-        strncpy(out->port, "443", sizeof(out->port) - 1);
-    } else if (strncmp(url, "http://", 7) == 0) {
-        out->use_tls = false;
-        url += 7;
-        strncpy(out->port, "80", sizeof(out->port) - 1);
-    } else {
-        return -1;
-    }
-
-    const char* slash = strchr(url, '/');
-    const char* colon = strchr(url, ':');
-
-    if (colon && (!slash || colon < slash)) {
-        size_t hlen = colon - url;
-        if (hlen >= sizeof(out->host))
-            hlen = sizeof(out->host) - 1;
-        memcpy(out->host, url, hlen);
-        out->host[hlen] = '\0';
-
-        colon++;
-        const char* pend = slash ? slash : colon + strlen(colon);
-        size_t plen = pend - colon;
-        if (plen >= sizeof(out->port))
-            plen = sizeof(out->port) - 1;
-        memcpy(out->port, colon, plen);
-        out->port[plen] = '\0';
-    } else {
-        size_t hlen = slash ? (size_t)(slash - url) : strlen(url);
-        if (hlen >= sizeof(out->host))
-            hlen = sizeof(out->host) - 1;
-        memcpy(out->host, url, hlen);
-        out->host[hlen] = '\0';
-    }
-
-    if (slash) {
-        strncpy(out->path, slash, sizeof(out->path) - 1);
-    } else {
-        strncpy(out->path, "/", sizeof(out->path) - 1);
-    }
-
-    return 0;
-}
 
 /* ── Data structures ────────────────────────────────────── */
 
@@ -481,7 +424,7 @@ int mcp_client_add_server(const char* name, const char* url,
         strncpy(srv->token, token, sizeof(srv->token) - 1);
     }
 
-    if (parse_url(url, &srv->parsed) != 0) {
+    if (url_parse(url, &srv->parsed) != 0) {
         syslog(LOG_ERR, "[%s] Invalid URL: %s\n", TAG, url);
         pthread_mutex_unlock(&s_mtx);
         return ERROR;

--- a/src/tools/tool_fetch_url.c
+++ b/src/tools/tool_fetch_url.c
@@ -23,6 +23,7 @@
 #include "tools/tool_fetch_url.h"
 #include "agent_config.h"
 #include "agent_compat.h"
+#include "infra/url_parse.h"
 #include "infra/vela_tls.h"
 #include "infra/http_proxy.h"
 
@@ -109,39 +110,24 @@ int tool_fetch_url_execute(const char *input_json, char *output, size_t output_s
         return ERROR;
     }
 
-    /* Parse URL: https://host[:port]/path */
-    if (strncmp(url, "https://", 8) != 0) {
+    /* Parse URL */
+    parsed_url_t pu;
+    if (url_parse(url, &pu) != 0 || !pu.use_tls
+        || strncmp(url, "https://", 8) != 0) {
         snprintf(output, output_size, "Error: only https:// URLs supported");
         cJSON_Delete(root);
         return ERROR;
     }
 
-    const char *hoststart = url + 8;
-    const char *slash = strchr(hoststart, '/');
-    const char *pathstart = slash ? slash : "/";
-
-    /* Extract host and port */
-    char host[256] = {0};
-    char port[8] = "443";
-    size_t hostlen = slash ? (size_t)(slash - hoststart) : strlen(hoststart);
-    if (hostlen >= sizeof(host)) hostlen = sizeof(host) - 1;
-    memcpy(host, hoststart, hostlen);
-
-    char *colon = strchr(host, ':');
-    if (colon) {
-        *colon = '\0';
-        strncpy(port, colon + 1, sizeof(port) - 1);
-    }
-
     /* SSRF protection: block private/loopback addresses */
-    if (is_private_host(host)) {
-        syslog(LOG_WARNING, "[%s] Blocked SSRF attempt to private host: %s\n", TAG, host);
+    if (is_private_host(pu.host)) {
+        syslog(LOG_WARNING, "[%s] Blocked SSRF attempt to private host: %s\n", TAG, pu.host);
         snprintf(output, output_size, "Error: access to private/internal addresses is not allowed");
         cJSON_Delete(root);
         return ERROR;
     }
 
-    syslog(LOG_INFO, "[%s] Fetching: %s (host=%s port=%s)\n", TAG, url, host, port);
+    syslog(LOG_INFO, "[%s] Fetching: %s (host=%s port=%s)\n", TAG, url, pu.host, pu.port);
 
     char *resp = malloc(FETCH_RESP_SIZE);
     if (!resp) {
@@ -150,10 +136,10 @@ int tool_fetch_url_execute(const char *input_json, char *output, size_t output_s
         return ERROR;
     }
 
-    int status = vela_https_get(host, port, pathstart, resp, FETCH_RESP_SIZE);
+    int status = vela_https_get(pu.host, pu.port, pu.path, resp, FETCH_RESP_SIZE);
 
     if (status != 200) {
-        snprintf(output, output_size, "Error: HTTP %d from %s", status, host);
+        snprintf(output, output_size, "Error: HTTP %d from %s", status, pu.host);
         free(resp);
         cJSON_Delete(root);
         return ERROR;
@@ -169,7 +155,7 @@ int tool_fetch_url_execute(const char *input_json, char *output, size_t output_s
                "returning placeholder\n", TAG, (int)resp_len);
         snprintf(output, output_size,
                  "[binary data: %d bytes from %s, "
-                 "not displayable as text]", (int)resp_len, host);
+                 "not displayable as text]", (int)resp_len, pu.host);
         free(resp);
         cJSON_Delete(root);
         return OK;
@@ -182,7 +168,7 @@ int tool_fetch_url_execute(const char *input_json, char *output, size_t output_s
     memcpy(output, resp, resp_len);
     output[resp_len] = '\0';
 
-    syslog(LOG_INFO, "[%s] Fetched %d bytes from %s\n", TAG, (int)resp_len, host);
+    syslog(LOG_INFO, "[%s] Fetched %d bytes from %s\n", TAG, (int)resp_len, pu.host);
     free(resp);
     cJSON_Delete(root);
     return OK;


### PR DESCRIPTION
Extract URL parsing into infra/url_parse.c, replacing 6 duplicate hand-written parsers across the codebase. Supports http, https, ws, wss schemes with host, port, path extraction.

Consumers migrated: mcp_client, cmd_llm, feishu_http, weixin_channel, tool_fetch_url, xiaozhi_channel.

Fixes: empty host validation, wss:// scheme bypass in fetch_url, path buffer expanded to 256 bytes for long query strings.

Verified on QEMU emulator: feishu WSS connect, fetch_url HTTPS, set_llm URL parsing all pass.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
