### PR TITLE
optimize: reduce stack usage and clean up dead code

### DIFF
--- a/src/channels/cmd_llm.c
+++ b/src/channels/cmd_llm.c
@@ -91,7 +91,7 @@ void cmd_set_llm(int argc, char** argv)
 
     /* Check if arg1 is a URL (http:// or https://) */
     if (strncmp(arg1, "http://", 7) == 0 || strncmp(arg1, "https://", 8) == 0) {
-        static parsed_url_t parsed;
+        parsed_url_t parsed;
         if (url_parse(arg1, &parsed) != 0) {
             printf("Invalid URL: %s\n", arg1);
             return;
@@ -107,7 +107,7 @@ void cmd_set_llm(int argc, char** argv)
         }
 
         /* Append /chat/completions if path is just /v1 */
-        static char full_path[256];
+        char full_path[256];
         if (strcmp(path, "/v1") == 0 || strcmp(path, "/v1/") == 0) {
             snprintf(full_path, sizeof(full_path), "/v1/chat/completions");
             path = full_path;

--- a/src/channels/xiaozhi_channel.c
+++ b/src/channels/xiaozhi_channel.c
@@ -50,13 +50,11 @@ static const char* TAG = "xiaozhi";
 /* ── State machine ────────────────────────────────────────── */
 
 static const uint8_t s_allowed[XZ_STATE_MAX][XZ_STATE_MAX] = {
-    /* DISC CONN MQTC CHOP UDPC ASTR */
-    { 0, 1, 0, 0, 0, 0 }, /* Disconnected */
-    { 1, 0, 1, 0, 0, 0 }, /* MqttConnecting (reused as WsConnecting) */
-    { 1, 0, 0, 1, 0, 0 }, /* MqttConnected (reused as WsConnected) */
-    { 1, 0, 1, 0, 0, 0 }, /* ChannelOpened */
-    { 1, 0, 0, 1, 0, 0 }, /* UdpConnected (unused in WS mode) */
-    { 1, 0, 0, 1, 0, 0 }, /* AudioStreaming (unused in WS mode) */
+    /* DISC CONN WCON CHOP */
+    { 0, 1, 0, 0 }, /* Disconnected */
+    { 1, 0, 1, 0 }, /* Connecting */
+    { 1, 0, 0, 1 }, /* Connected */
+    { 1, 0, 1, 0 }, /* ChannelOpened */
 };
 
 static xiaozhi_state_t s_state = XZ_STATE_DISCONNECTED;
@@ -456,7 +454,7 @@ static void* ws_task(void* arg)
 
         /* Receive loop */
         {
-            char buf[8192];
+            char buf[4096];
             while (s_running) {
                 uint8_t opcode = 0;
                 int n = ws_client_recv(&s_ws, &opcode, buf, sizeof(buf) - 1);

--- a/src/channels/xiaozhi_state.h
+++ b/src/channels/xiaozhi_state.h
@@ -26,11 +26,9 @@
 
 typedef enum {
     XZ_STATE_DISCONNECTED = 0,
-    XZ_STATE_CONNECTING,       /* was MQTT_CONNECTING, now WS connecting */
-    XZ_STATE_CONNECTED,        /* was MQTT_CONNECTED, now WS connected */
+    XZ_STATE_CONNECTING,
+    XZ_STATE_CONNECTED,
     XZ_STATE_CHANNEL_OPENED,
-    XZ_STATE_UDP_CONNECTED,    /* reserved for MQTT+UDP mode */
-    XZ_STATE_AUDIO_STREAMING,  /* reserved for MQTT+UDP mode */
     XZ_STATE_MAX
 } xiaozhi_state_t;
 
@@ -41,8 +39,6 @@ static inline const char* xiaozhi_state_name(xiaozhi_state_t s)
         "Connecting",
         "Connected",
         "ChannelOpened",
-        "UdpConnected",
-        "AudioStreaming",
     };
 
     if (s >= 0 && s < XZ_STATE_MAX) {


### PR DESCRIPTION
- xiaozhi_channel.c: WS recv buffer 8192->4096 (saves 4KB stack)
- xiaozhi_state.h: remove unused UDP/AudioStreaming states (6->4)
- xiaozhi_channel.c: shrink state transition table 6x6->4x4
- agent_loop.c: music search buffer 4096->2048 (saves 2KB stack)
- cmd_llm.c: static local->stack (frees 648B BSS)

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
