### PR TITLE
docs: sync CLI and README with current MCP/Skills support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - 📡 **多渠道接入** — CLI / 飞书 Bot / 微信 Bot / WebSocket / MQTT / 语音（ASR+TTS），统一消息总线，均可通过 Kconfig 独立开关
 - 🌐 **多节点协作** — Hub 模式接受设备连接，Node 模式连接 OpenClaw Gateway，跨设备工具调用
 - 🔌 **MCP 协议** — 设备端 MCP Client 通过 Streamable HTTP 直连远程 MCP Server（已验证高德地图 15 工具、滴滴出行 13 工具），动态发现和调用远程工具
-- 📝 **Skills 系统** — Markdown 格式可扩展技能，10 个内置 Skill，对话即可创建新技能
+- 📝 **Skills 系统** — Markdown 格式可扩展技能，内置多个 Skill，对话即可创建新技能
 - 🔒 **安全加固** — 工具白名单、敏感工具限流、Shell 三级策略、日志脱敏
 - 💾 **低内存优化** — 堆检测、内存池、流式输出，模块化 Kconfig 裁剪，适配手表级设备（~256KB RAM）
 - 🔀 **智能路由** — 多后端 LLM Router，复杂度感知路由、自动故障转移、成本优化
@@ -58,7 +58,7 @@ vela> mcp_discover                       # 发现远程工具
 | `qwen` | qwen-turbo | 通义千问 |
 | `deepseek` | deepseek-chat | DeepSeek |
 | `glm` | glm-4-flash | 智谱 AI |
-| `mimo` | MiMo-v2-Flash | 小米大模型（Flash/Pro/Omni） |
+| `mimo` | `mimo-v2-flash` | 小米大模型（Flash/Pro/Omni） |
 | `openai` | gpt-4o | OpenAI |
 | `claude` | claude-sonnet-4-20250514 | Anthropic Claude |
 | `openrouter` | openrouter/hunter-alpha | OpenRouter 聚合 |
@@ -114,7 +114,7 @@ vela> router_status                      # 查看路由状态
 
 ## Skills 系统
 
-10 个内置 Skill，Markdown 格式，对话即可创建新技能：
+内置多个 Skill，Markdown 格式，对话即可创建新技能：
 
 | Skill | 说明 |
 |-------|------|

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -87,6 +87,17 @@ AI Agent 通过 NuttX NSH shell 提供以下命令。启动后输入 `help` 查�
 | `node_stop` | 断开 Node 连接 |
 | `node_list` | 列出已连接 Node |
 
+## Skills 与 MCP
+
+| 命令 | 说明 |
+|------|------|
+| `install_skill <name> <url>` | 从 HTTPS URL 下载并安装 Skill Markdown 文件 |
+| `mcp_add <name> <url> [token]` | 添加远程 MCP Server |
+| `mcp_remove <name>` | 移除远程 MCP Server |
+| `mcp_discover` | 从所有已添加的 MCP Server 发现远程工具 |
+| `mcp_status` | 查看 MCP Client 连接状态 |
+| `mcp_tools` | 列出已发现的远程 MCP 工具 |
+
 ## 会话与记忆
 
 | 命令 | 说明 |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -9,7 +9,7 @@ Skills 是 Markdown 格式的可扩展技能，告诉 Agent 在特定场景下�
 ├── weather.md          ← 内置（首次启动自动安装）
 ├── daily-briefing.md
 ├── reminder.md
-├── ...                 ← 10 个内置 Skill
+├── ...                 ← 多个内置 Skill
 └── my-custom.md        ← 用户自定义
 
 启动流程：
@@ -38,7 +38,7 @@ agent_loop → 根据用户请求匹配 Skill → 按指引调用工具
 2. 提取每个 Skill 的标题和描述，构建摘要注入系统提示词
 3. Agent 根据用户请求自动匹配合适的 Skill 并按其指引执行
 
-## 内置 Skills（10 个）
+## 内置 Skills（示例）
 
 | Skill | 说明 |
 |-------|------|


### PR DESCRIPTION
## Summary
- document missing CLI commands for skill installation and MCP management
- replace outdated "10 built-in Skills" wording with non-fixed wording
- align the Mimo model name in README with the actual preset (`mimo-v2-flash`)

## Impact
- improves consistency between `README.md`, `docs/cli.md`, `docs/skills.md`, and the current NSH commands
- reduces confusion for users trying to use MCP-related CLI commands
- avoids outdated documentation as the number of built-in skills grows

## Testing
- verified documented commands against `src/channels/nsh_commands.c`
- verified the Mimo preset name against `src/channels/cmd_llm.c`
- checked current built-in skill files under `agent_skills/`