### PR TITLE
tools: add hardware diagnostics, TTS, and device skills

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,10 @@ CSRCS += src/tools/tool_system.c
 CSRCS += src/tools/tool_health.c
 CSRCS += src/tools/tool_control.c
 CSRCS += src/tools/tool_media.c
+CSRCS += src/tools/tool_network_probe.c
+CSRCS += src/tools/tool_peripheral.c
 CSRCS += src/tools/tool_proxyquickapp.c
+CSRCS += src/tools/tool_tts.c
 ifeq ($(CONFIG_AI_AGENT_MCP),y)
 CSRCS += src/tools/mcp_bridge.c
 CSRCS += src/tools/mcp_server.c

--- a/agent_skills/device-self-check.md
+++ b/agent_skills/device-self-check.md
@@ -1,0 +1,22 @@
+# Device Self Check
+
+Check the board's network and multimedia peripherals, then report a concise
+pass/fail summary.
+
+## When to use
+When the user asks whether the camera, microphone, speaker, display, I2S, or
+network is ready.
+
+## How to use
+1. Call `peripheral_status`.
+2. Call `network_probe` with `apply=false`.
+3. Report every missing device node and all reachable DNS servers.
+4. If the speaker is available and the user requested an audible result,
+   call `tts_speak` with the summary.
+5. Never call `network_probe` with `apply=true` unless the user explicitly
+   asks to change DNS.
+
+## Result
+Separate hardware presence from end-to-end functional verification. A
+present device node means registered, not that image or audio quality has
+been verified.

--- a/agent_skills/meal-planner.md
+++ b/agent_skills/meal-planner.md
@@ -1,0 +1,18 @@
+# Meal Planner
+
+Create a daily three-meal plan from the date, saved preferences, and optional
+activity data.
+
+## When to use
+When the user asks what to eat, requests a meal plan, or wants a daily calorie
+estimate.
+
+## How to use
+1. Call `get_current_time` and determine whether today is a weekday.
+2. Read `/data/agent/memory/MEMORY.md` for allergies, preferences, and goals.
+   Never recommend a known allergen.
+3. Optionally call `get_steps` to estimate activity. If unavailable, use a
+   neutral activity level.
+4. Provide breakfast, lunch, and dinner with approximate calories and a daily
+   total. Label all nutrition numbers as estimates.
+5. For medical diets, advise confirmation with a qualified clinician.

--- a/agent_skills/visual-guide.md
+++ b/agent_skills/visual-guide.md
@@ -1,0 +1,27 @@
+# Visual Guide
+
+Describe the camera view aloud as an informational aid. This skill does not
+guarantee a safe route and must not replace a mobility aid.
+
+## When to use
+When the user asks what is ahead, requests a scene description, or asks the
+device to read visible text aloud.
+
+## How to use
+1. Call `peripheral_status`. In its `devices` array, require the camera and
+   `audio_playback` entries to have `available=true`.
+2. Call `network_probe` with `apply=false`. A failure is a warning, not a
+   reason to skip local hardware checks.
+3. Call `camera_capture` with `resolution=high` and ask for observable
+   objects, approximate relative positions, and visible text. Never state
+   that a route is certainly safe.
+4. Extract `analysis` from the result. If it is empty, speak a short failure
+   message.
+5. Call `tts_speak` with chunks no longer than 100 Chinese characters or
+   300 English characters.
+
+## Fallback
+- Camera unavailable: use `tts_speak` to report that the camera is not ready.
+- TTS unavailable: return the camera analysis as text.
+- Network unavailable: do not change DNS automatically; report the
+  diagnostic result.

--- a/src/tools/skill_loader.c
+++ b/src/tools/skill_loader.c
@@ -195,6 +195,48 @@ static const char *TAG = "skills";
     "- Add: get_current_time, then edit_file/write_file to append: - [ ] [YYYY-MM-DD] desc\n" \
     "- Complete: edit_file to change - [ ] to - [x]\n"
 
+#define BUILTIN_VISUAL_GUIDE \
+    "# Visual Guide\n\n" \
+    "Describe the camera view aloud as an informational aid. This skill does not guarantee a safe route and must not replace a mobility aid.\n\n" \
+    "## When to use\n" \
+    "When the user asks what is ahead, requests a scene description, or asks the device to read visible text aloud.\n\n" \
+    "## How to use\n" \
+    "1. Call peripheral_status. In its devices array, require the camera and audio_playback entries to have available=true.\n" \
+    "2. Call network_probe with apply=false. A failure is a warning, not a reason to skip local hardware checks.\n" \
+    "3. Call camera_capture with resolution=high and ask for observable objects, approximate relative positions, and visible text. Never state that a route is certainly safe.\n" \
+    "4. Extract analysis from the result. If it is empty, speak a short failure message.\n" \
+    "5. Call tts_speak with chunks no longer than 100 Chinese characters or 300 English characters.\n\n" \
+    "## Fallback\n" \
+    "- Camera unavailable: use tts_speak to report that the camera is not ready.\n" \
+    "- TTS unavailable: return the camera analysis as text.\n" \
+    "- Network unavailable: do not change DNS automatically; report the diagnostic result.\n"
+
+#define BUILTIN_DEVICE_SELF_CHECK \
+    "# Device Self Check\n\n" \
+    "Check the board's network and multimedia peripherals, then report a concise pass/fail summary.\n\n" \
+    "## When to use\n" \
+    "When the user asks whether the camera, microphone, speaker, display, I2S, or network is ready.\n\n" \
+    "## How to use\n" \
+    "1. Call peripheral_status.\n" \
+    "2. Call network_probe with apply=false.\n" \
+    "3. Report every missing device node and all reachable DNS servers.\n" \
+    "4. If the speaker is available and the user requested an audible result, call tts_speak with the summary.\n" \
+    "5. Never call network_probe with apply=true unless the user explicitly asks to change DNS.\n\n" \
+    "## Result\n" \
+    "Separate hardware presence from end-to-end functional verification. A present device node means registered, not that image or audio quality has been verified.\n"
+
+#define BUILTIN_MEAL_PLANNER \
+    "# Meal Planner\n\n" \
+    "Create a daily three-meal plan from the date, saved preferences, and optional activity data.\n\n" \
+    "## When to use\n" \
+    "When the user asks what to eat, requests a meal plan, or wants a daily calorie estimate.\n\n" \
+    "## How to use\n" \
+    "1. Call get_current_time and determine whether today is a weekday.\n" \
+    "2. Read " AGENT_MEMORY_DIR "/MEMORY.md for allergies, preferences, and goals. Never recommend a known allergen.\n" \
+    "3. Optionally call get_steps to estimate activity. If unavailable, use a neutral activity level.\n" \
+    "4. Provide breakfast, lunch, and dinner with approximate calories and a daily total. Label all nutrition numbers as estimates.\n" \
+    "5. For medical diets, advise confirmation with a qualified clinician.\n"
+
 /* Built-in skill registry */
 typedef struct {
     const char *filename;   /* e.g. "weather" */
@@ -212,6 +254,9 @@ static const builtin_skill_t s_builtins[] = {
     { "news-digest",    BUILTIN_NEWS_DIGEST    },
     { "feishu-test",    BUILTIN_FEISHU_TEST    },
     { "task-manager",   BUILTIN_TASK_MANAGER   },
+    { "visual-guide",   BUILTIN_VISUAL_GUIDE   },
+    { "device-self-check", BUILTIN_DEVICE_SELF_CHECK },
+    { "meal-planner",   BUILTIN_MEAL_PLANNER   },
 };
 
 #define NUM_BUILTINS (sizeof(s_builtins) / sizeof(s_builtins[0]))

--- a/src/tools/tool_network_probe.c
+++ b/src/tools/tool_network_probe.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tools/tool_network_probe.h"
+#include "agent_compat.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "cJSON.h"
+
+#define DNS_PORT 53
+#define DNS_PROBE_COUNT 2
+#define DNS_PROBE_TIMEOUT_MS 1200
+#ifdef CONFIG_NETDB_RESOLVCONF_PATH
+#define RESOLV_CONF_PATH CONFIG_NETDB_RESOLVCONF_PATH
+#else
+#define RESOLV_CONF_PATH "/etc/resolv.conf"
+#endif
+
+static const char* const g_dns_candidates[] = {
+    "223.5.5.5",
+    "119.29.29.29",
+    "1.1.1.1",
+    "8.8.8.8",
+};
+
+static const uint8_t g_dns_query[] = {
+    0xab,
+    0xcd,
+    0x01,
+    0x00,
+    0x00,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x03,
+    'w',
+    'w',
+    'w',
+    0x07,
+    'e',
+    'x',
+    'a',
+    'm',
+    'p',
+    'l',
+    'e',
+    0x03,
+    'c',
+    'o',
+    'm',
+    0x00,
+    0x00,
+    0x01,
+    0x00,
+    0x01,
+};
+
+struct dns_result_s {
+    const char* address;
+    long latency_ms;
+};
+
+static long timespec_diff_ms(const struct timespec* start,
+    const struct timespec* end)
+{
+    long elapsed;
+
+    elapsed = (end->tv_sec - start->tv_sec) * 1000L;
+    elapsed += (end->tv_nsec - start->tv_nsec) / 1000000L;
+    return elapsed < 0 ? 0 : elapsed;
+}
+
+static long probe_dns_once(const char* address)
+{
+    struct sockaddr_in server;
+    struct timespec start;
+    struct timespec end;
+    struct timeval timeout;
+    fd_set readfds;
+    uint8_t response[64];
+    ssize_t size;
+    int fd;
+    int ret;
+
+    fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (fd < 0) {
+        return -1;
+    }
+
+    memset(&server, 0, sizeof(server));
+    server.sin_family = AF_INET;
+    server.sin_port = htons(DNS_PORT);
+    if (inet_pton(AF_INET, address, &server.sin_addr) != 1) {
+        close(fd);
+        return -1;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    size = sendto(fd, g_dns_query, sizeof(g_dns_query), 0,
+        (struct sockaddr*)&server, sizeof(server));
+    if (size != (ssize_t)sizeof(g_dns_query)) {
+        close(fd);
+        return -1;
+    }
+
+    FD_ZERO(&readfds);
+    FD_SET(fd, &readfds);
+    timeout.tv_sec = DNS_PROBE_TIMEOUT_MS / 1000;
+    timeout.tv_usec = (DNS_PROBE_TIMEOUT_MS % 1000) * 1000;
+
+    ret = select(fd + 1, &readfds, NULL, NULL, &timeout);
+    if (ret <= 0) {
+        close(fd);
+        return -1;
+    }
+
+    size = recv(fd, response, sizeof(response), 0);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    close(fd);
+
+    if (size < 2 || response[0] != g_dns_query[0] || response[1] != g_dns_query[1]) {
+        return -1;
+    }
+
+    return timespec_diff_ms(&start, &end);
+}
+
+static long probe_dns(const char* address)
+{
+    long best = -1;
+    int i;
+
+    for (i = 0; i < DNS_PROBE_COUNT; i++) {
+        long latency = probe_dns_once(address);
+
+        if (latency >= 0 && (best < 0 || latency < best)) {
+            best = latency;
+        }
+    }
+
+    return best;
+}
+
+static int update_resolver(const char* primary, const char* secondary)
+{
+    FILE* stream;
+
+    stream = fopen(RESOLV_CONF_PATH, "w");
+    if (stream == NULL) {
+        return -errno;
+    }
+
+    fprintf(stream, "nameserver %s\n", primary);
+    if (secondary != NULL) {
+        fprintf(stream, "nameserver %s\n", secondary);
+    }
+
+    if (fclose(stream) != 0) {
+        return -errno;
+    }
+
+    return OK;
+}
+
+static void sort_results(struct dns_result_s* results, size_t count)
+{
+    size_t i;
+    size_t j;
+
+    for (i = 0; i + 1 < count; i++) {
+        size_t best = i;
+
+        for (j = i + 1; j < count; j++) {
+            if (results[j].latency_ms >= 0 && (results[best].latency_ms < 0 || results[j].latency_ms < results[best].latency_ms)) {
+                best = j;
+            }
+        }
+
+        if (best != i) {
+            struct dns_result_s swap = results[i];
+
+            results[i] = results[best];
+            results[best] = swap;
+        }
+    }
+}
+
+int tool_network_probe_execute(const char* input_json, char* output,
+    size_t output_size)
+{
+    struct dns_result_s results[nitems(g_dns_candidates)];
+    const char* secondary = NULL;
+    cJSON* probe_results;
+    cJSON* request;
+    cJSON* root;
+    cJSON* item;
+    char* serialized;
+    bool apply = false;
+    bool updated = false;
+    int reachable = 0;
+    int update_result = 0;
+    size_t i;
+
+    request = cJSON_Parse(input_json != NULL ? input_json : "{}");
+    if (request == NULL) {
+        snprintf(output, output_size, "{\"error\":\"invalid JSON\"}");
+        return ERROR;
+    }
+
+    item = cJSON_GetObjectItemCaseSensitive(request, "apply");
+    if (cJSON_IsBool(item)) {
+        apply = cJSON_IsTrue(item);
+    }
+
+    cJSON_Delete(request);
+
+    for (i = 0; i < nitems(g_dns_candidates); i++) {
+        results[i].address = g_dns_candidates[i];
+        results[i].latency_ms = probe_dns(results[i].address);
+        if (results[i].latency_ms >= 0) {
+            reachable++;
+        }
+    }
+
+    sort_results(results, nitems(results));
+    if (reachable == 0) {
+        snprintf(output, output_size,
+            "{\"error\":\"no DNS server responded\",\"reachable\":0}");
+        return ERROR;
+    }
+
+    if (reachable > 1) {
+        secondary = results[1].address;
+    }
+
+    if (apply) {
+        update_result = update_resolver(results[0].address, secondary);
+        updated = update_result == OK;
+    }
+
+    root = cJSON_CreateObject();
+    probe_results = cJSON_CreateArray();
+    if (root == NULL || probe_results == NULL) {
+        cJSON_Delete(root);
+        cJSON_Delete(probe_results);
+        snprintf(output, output_size, "{\"error\":\"out of memory\"}");
+        return ERROR;
+    }
+
+    cJSON_AddNumberToObject(root, "reachable", reachable);
+    cJSON_AddStringToObject(root, "recommended_primary", results[0].address);
+    if (secondary != NULL) {
+        cJSON_AddStringToObject(root, "recommended_secondary", secondary);
+    }
+
+    cJSON_AddBoolToObject(root, "apply_requested", apply);
+    cJSON_AddBoolToObject(root, "config_updated", updated);
+    if (apply && !updated) {
+        cJSON_AddNumberToObject(root, "update_error", update_result);
+    }
+
+    for (i = 0; i < nitems(results); i++) {
+        item = cJSON_CreateObject();
+        cJSON_AddStringToObject(item, "server", results[i].address);
+        if (results[i].latency_ms >= 0) {
+            cJSON_AddNumberToObject(item, "latency_ms",
+                results[i].latency_ms);
+        } else {
+            cJSON_AddNullToObject(item, "latency_ms");
+        }
+
+        cJSON_AddItemToArray(probe_results, item);
+    }
+
+    cJSON_AddItemToObject(root, "probe_results", probe_results);
+    serialized = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (serialized == NULL) {
+        snprintf(output, output_size, "{\"error\":\"out of memory\"}");
+        return ERROR;
+    }
+
+    snprintf(output, output_size, "%s", serialized);
+    free(serialized);
+    return apply && !updated ? ERROR : OK;
+}

--- a/src/tools/tool_network_probe.h
+++ b/src/tools/tool_network_probe.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+int tool_network_probe_execute(const char* input_json, char* output,
+    size_t output_size);

--- a/src/tools/tool_peripheral.c
+++ b/src/tools/tool_peripheral.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tools/tool_peripheral.h"
+#include "agent_compat.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+
+#include "cJSON.h"
+
+struct peripheral_s {
+    const char* name;
+    const char* path;
+};
+
+static const struct peripheral_s g_peripherals[] = {
+    { "audio_capture", "/dev/audio/pcm_in0" },
+    { "audio_playback", "/dev/audio/pcm0" },
+    { "camera", "/dev/video0" },
+    { "display", "/dev/lcd0" },
+    { "i2s", "/dev/i2schar0" },
+};
+
+int tool_peripheral_status_execute(const char* input_json, char* output,
+    size_t output_size)
+{
+    cJSON* devices;
+    cJSON* root;
+    char* serialized;
+    int available = 0;
+    size_t i;
+
+    (void)input_json;
+
+    root = cJSON_CreateObject();
+    devices = cJSON_CreateArray();
+    if (root == NULL || devices == NULL) {
+        cJSON_Delete(root);
+        cJSON_Delete(devices);
+        snprintf(output, output_size, "{\"error\":\"out of memory\"}");
+        return ERROR;
+    }
+
+    for (i = 0; i < nitems(g_peripherals); i++) {
+        struct stat status;
+        cJSON* device = cJSON_CreateObject();
+        int ret;
+        int saved_errno;
+
+        errno = 0;
+        ret = stat(g_peripherals[i].path, &status);
+        saved_errno = errno;
+
+        cJSON_AddStringToObject(device, "name", g_peripherals[i].name);
+        cJSON_AddStringToObject(device, "path", g_peripherals[i].path);
+        cJSON_AddBoolToObject(device, "available", ret == 0);
+        if (ret == 0) {
+            available++;
+        } else {
+            cJSON_AddNumberToObject(device, "errno", saved_errno);
+        }
+
+        cJSON_AddItemToArray(devices, device);
+    }
+
+    cJSON_AddNumberToObject(root, "available_count", available);
+    cJSON_AddNumberToObject(root, "checked_count", nitems(g_peripherals));
+    cJSON_AddItemToObject(root, "devices", devices);
+
+    serialized = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (serialized == NULL) {
+        snprintf(output, output_size, "{\"error\":\"out of memory\"}");
+        return ERROR;
+    }
+
+    snprintf(output, output_size, "%s", serialized);
+    free(serialized);
+    return OK;
+}

--- a/src/tools/tool_peripheral.h
+++ b/src/tools/tool_peripheral.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+int tool_peripheral_status_execute(const char* input_json, char* output,
+    size_t output_size);

--- a/src/tools/tool_registry.c
+++ b/src/tools/tool_registry.c
@@ -35,9 +35,12 @@
 #include "tools/tool_get_time.h"
 #include "tools/tool_health.h"
 #include "tools/tool_media.h"
+#include "tools/tool_network_probe.h"
+#include "tools/tool_peripheral.h"
 #include "tools/tool_proxyquickapp.h"
 #include "tools/tool_shell.h"
 #include "tools/tool_system.h"
+#include "tools/tool_tts.h"
 #include "tools/tool_vision.h"
 #include "tools/tool_camera.h"
 #include "tools/tool_web_search.h"
@@ -210,6 +213,15 @@ int tool_registry_init(void)
         "Get current date, time, and UNIX epoch.",
         tool_get_time_execute);
 
+    REGISTER_TOOL(
+        "network_probe",
+        "Measure DNS reachability and latency. Read-only unless apply=true.",
+        TOOL_SCHEMA_BEGIN()
+            TOOL_PARAM_BOOL("apply",
+                "Apply recommended DNS servers to the configured resolver file")
+                TOOL_SCHEMA_END(),
+        tool_network_probe_execute);
+
     /* File tools */
     REGISTER_TOOL("read_file",
         "Read a file. Path must start with " AGENT_DATA_DIR "/.",
@@ -347,6 +359,12 @@ int tool_registry_init(void)
         "Check if screen is on or off.",
         tool_get_screen_state_execute);
 
+    REGISTER_TOOL_NO_PARAMS(
+        "peripheral_status",
+        "Check camera, display, I2S, audio capture, and audio playback "
+        "device-node availability.",
+        tool_peripheral_status_execute);
+
     /* Health / fitness tools */
     REGISTER_TOOL_NO_PARAMS(
         "get_heartrate",
@@ -483,6 +501,14 @@ int tool_registry_init(void)
         "Get current music playback status including state, "
         "position, duration, volume, and track URL.",
         tool_music_status_execute);
+
+    REGISTER_TOOL(
+        "tts_speak",
+        "Synthesize text and play it through the device speaker.",
+        TOOL_SCHEMA_BEGIN()
+            TOOL_PARAM_STR("text", "UTF-8 text to speak, up to 600 bytes")
+                TOOL_SCHEMA_END_REQUIRED("\"text\""),
+        tool_tts_speak_execute);
 
     /* QuickApp launch tool */
     REGISTER_TOOL("launch_quickapp",

--- a/src/tools/tool_tts.c
+++ b/src/tools/tool_tts.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tools/tool_tts.h"
+#include "agent_compat.h"
+#include "voice/voice_channel.h"
+#include "voice/voice_tts.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+
+#define TTS_TOOL_TEXT_MAX 600
+
+int tool_tts_speak_execute(const char* input_json, char* output,
+    size_t output_size)
+{
+    const char* backend;
+    const cJSON* text;
+    cJSON* request;
+    cJSON* root;
+    char* serialized;
+    int ret;
+
+    request = cJSON_Parse(input_json != NULL ? input_json : "{}");
+    if (request == NULL) {
+        snprintf(output, output_size, "{\"error\":\"invalid JSON\"}");
+        return ERROR;
+    }
+
+    text = cJSON_GetObjectItemCaseSensitive(request, "text");
+    if (!cJSON_IsString(text) || text->valuestring[0] == '\0') {
+        cJSON_Delete(request);
+        snprintf(output, output_size,
+            "{\"error\":\"text must be a non-empty string\"}");
+        return ERROR;
+    }
+
+    if (strlen(text->valuestring) > TTS_TOOL_TEXT_MAX) {
+        cJSON_Delete(request);
+        snprintf(output, output_size,
+            "{\"error\":\"text exceeds %d bytes\"}",
+            TTS_TOOL_TEXT_MAX);
+        return ERROR;
+    }
+
+    backend = voice_tts_get_backend();
+    if (backend == NULL) {
+        cJSON_Delete(request);
+        snprintf(output, output_size,
+            "{\"error\":\"TTS backend is not configured\"}");
+        return ERROR;
+    }
+
+    ret = voice_channel_speak(text->valuestring);
+    cJSON_Delete(request);
+    if (ret < 0) {
+        snprintf(output, output_size,
+            "{\"error\":\"TTS playback failed\",\"code\":%d}", ret);
+        return ERROR;
+    }
+
+    root = cJSON_CreateObject();
+    if (root == NULL) {
+        snprintf(output, output_size, "{\"error\":\"out of memory\"}");
+        return ERROR;
+    }
+
+    cJSON_AddStringToObject(root, "status", "ok");
+    cJSON_AddStringToObject(root, "backend", backend);
+    serialized = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (serialized == NULL) {
+        snprintf(output, output_size, "{\"error\":\"out of memory\"}");
+        return ERROR;
+    }
+
+    snprintf(output, output_size, "%s", serialized);
+    free(serialized);
+    return OK;
+}

--- a/src/tools/tool_tts.h
+++ b/src/tools/tool_tts.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+int tool_tts_speak_execute(const char* input_json, char* output,
+    size_t output_size);


### PR DESCRIPTION
Add reusable network, peripheral, and TTS tools together with built-in visual guide, device self-check, and meal planner skills.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

Dependency: replace this line with the merged AI Agent build-source PR link
before submission.

## Summary

Add three reusable C tools and three built-in skills to the AI Agent.

- network_probe measures DNS reachability and latency. It is read-only by
  default and updates the configured resolver only with apply=true.
- peripheral_status reports audio capture, audio playback, camera, LCD, and
  I2S device-node availability.
- tts_speak validates bounded text input and reuses the existing voice channel
  for synthesis and playback.
- Visual Guide checks hardware first and describes camera observations as an
  informational aid without claiming that a route is safe.
- Device Self Check distinguishes registered nodes from end-to-end function.
- Meal Planner uses time, memory preferences, and optional activity data while
  labeling nutrition values as estimates.

## Impact

- Adds no new public library API and does not change existing tool behavior.
- Adds three small C implementations, three Markdown Skill sources, and their
  built-in forms to the image.
- network_probe writes configuration only when apply=true is explicitly
  supplied.
- peripheral_status is read-only.
- tts_speak uses an already configured backend and stores no credentials.
- Missing board drivers are reported as unavailable; the tools do not register
  hardware themselves.
- No defconfig, NuttX driver, generated file, or credential is included.

## Testing

- Host: Linux x86_64.
- Compiler: xtensa-esp32s3-elf-gcc.
- Formatter: clang-format 14.0.6, WebKit style.
- Target: ESP32-S3-Korvo-2 with NSH, Wi-Fi, application mbedTLS, audio, and AI
  Agent enabled.
- Base: packages_ai_agent dev 721d09fc37.
- Applied the prerequisite build-source fix and this change to a clean tree.
- Compiled tool_network_probe.c, tool_peripheral.c, tool_tts.c, the skill
  loader, and the registry.
- Completed the final NuttX link and generated nuttx, nuttx.hex, and nuttx.bin.
- git diff --check passed.
- All new C/H files passed clang-format 14 WebKit checks. Existing source
  layout is unchanged outside the added registration and Skill blocks.