### PR TITLE
fix(ai_agent): VelaGuard board daemon attach and tool reliability

### DIFF
--- a/include/agent_config.h
+++ b/include/agent_config.h
@@ -116,7 +116,7 @@
  * a timeout and replies with a user-friendly error message.
  * The socket-level SO_RCVTIMEO (AGENT_LLM_SOCKET_TIMEOUT_SEC)
  * acts as the hard backstop that actually unblocks the read. */
-#define AGENT_LLM_TIMEOUT_SEC 60
+#define AGENT_LLM_TIMEOUT_SEC 120
 
 /* Socket-level read timeout applied via SO_RCVTIMEO in vela_tls.
  * Must be >= AGENT_LLM_TIMEOUT_SEC to allow the agent-level

--- a/src/agent_main.c
+++ b/src/agent_main.c
@@ -86,6 +86,35 @@
 
 static const char* TAG = "agent";
 
+/* Daemon autostart (--daemon): cron/heartbeat/network, no stdin CLI. */
+static volatile bool g_daemon_running = false;
+
+static bool argv_has_flag(int argc, char* argv[], const char* flag)
+{
+    for (int i = 1; i < argc; i++) {
+        if (argv[i] != NULL && strcmp(argv[i], flag) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* NuttX boards without RTC boot at epoch; TLS may jump the clock mid-call.
+ * Set a sane wall clock once at agent start, before any HTTPS traffic. */
+static void ensure_wall_clock_for_tls(void)
+{
+    time_t now = time(NULL);
+
+    if (now >= 1704067200) { /* Jan 1 2024 UTC */
+        return;
+    }
+
+    struct timespec ts = { .tv_sec = 1772275200, .tv_nsec = 0 }; /* 2026-02-28 */
+    clock_settime(CLOCK_REALTIME, &ts);
+    syslog(LOG_WARNING, "[%s] Wall clock was stale (%ld), set for TLS\n",
+        TAG, (long)now);
+}
+
 /* ── stdout mutex — shared with nsh_commands.c ──────────────── */
 /* Prevents concurrent printf from outbound_dispatch_task and cli_thread
  * which causes adbd shell_service_uv assert (wait_ack != 0). */
@@ -466,8 +495,25 @@ static inline long boot_ms(struct timespec* t0)
 
 int ai_agent_main(int argc, char* argv[])
 {
-    (void)argc;
-    (void)argv;
+    const bool daemon_mode = argv_has_flag(argc, argv, "--daemon");
+    const bool skip_cli = daemon_mode;
+
+    if (daemon_mode) {
+        if (g_daemon_running) {
+            return 0;
+        }
+    } else if (g_daemon_running) {
+        /* Background daemon is up; attach an interactive CLI on NSH stdin. */
+        syslog(LOG_INFO, "[%s] Attaching CLI to daemon agent\n", TAG);
+        nsh_commands_set_detach_quit(true);
+        nsh_commands_run_interactive();
+        nsh_commands_set_detach_quit(false);
+        return 0;
+    }
+
+    if (daemon_mode) {
+        g_daemon_running = true;
+    }
 
     g_shutdown_requested = false;
 
@@ -485,6 +531,7 @@ int ai_agent_main(int argc, char* argv[])
 #ifdef CONFIG_LIBC_LOCALTIME
     tzset();
 #endif
+    ensure_wall_clock_for_tls();
     BOOT_LOG(&t0, "P0", "timezone set");
 
     /* ── Phase 0: Storage Bootstrapping (Auto-mount & Mkdir) ── */
@@ -518,8 +565,12 @@ int ai_agent_main(int argc, char* argv[])
 
         rc = message_bus_init();
         BOOT_LOG_RC(&t0, "P1", "message_bus_init", rc);
-        if (rc != OK)
+        if (rc != OK) {
+            if (daemon_mode) {
+                g_daemon_running = false;
+            }
             return -1;
+        }
 
         rc = memory_store_init();
         BOOT_LOG_RC(&t0, "P1", "memory_store_init", rc);
@@ -618,6 +669,9 @@ int ai_agent_main(int argc, char* argv[])
             AGENT_OUTBOUND_PRIO)
         != OK) {
         syslog(LOG_ERR, "[%s] Failed to start outbound dispatch thread\n", TAG);
+        if (daemon_mode) {
+            g_daemon_running = false;
+        }
         return -1;
     }
     BOOT_LOG(&t0, "P5", "outbound dispatch thread started");
@@ -692,9 +746,11 @@ int ai_agent_main(int argc, char* argv[])
     BOOT_LOG(&t0, "P5", "network_watch thread started (async)");
 
     /* ── Phase 6: CLI thread — all services now in known state ── */
-    {
+    if (!skip_cli) {
         int rc = nsh_commands_start();
         BOOT_LOG_RC(&t0, "P6", "nsh_commands_start", rc);
+    } else {
+        BOOT_LOG(&t0, "P6", "nsh_commands skipped (daemon mode)");
     }
 
     syslog(LOG_INFO, "[%s] [boot +%ldms] AI Agent ready. Type 'help' in NSH for commands.\n",
@@ -752,5 +808,8 @@ int ai_agent_main(int argc, char* argv[])
 
     syslog(LOG_INFO, "[%s] Shutdown complete.\n", TAG);
 
+    if (daemon_mode) {
+        g_daemon_running = false;
+    }
     return 0;
 }

--- a/src/channels/nsh_commands.c
+++ b/src/channels/nsh_commands.c
@@ -70,6 +70,7 @@
 #endif
 
 static const char* TAG = "cli";
+static bool g_detach_quit = false;
 
 #define MAX_ARGS 8
 #define LINE_LEN 256
@@ -661,7 +662,9 @@ static void cmd_quit(void)
 {
     printf("Exiting agent...\n");
     fflush(stdout);
-    agent_request_shutdown();
+    if (!g_detach_quit) {
+        agent_request_shutdown();
+    }
 }
 
 static void cmd_launch_app(int argc, char** argv)
@@ -1087,4 +1090,15 @@ int nsh_commands_init(void)
 int nsh_commands_start(void)
 {
     return agent_task_create(cli_thread, "agent_cli", AGENT_CLI_STACK, NULL, AGENT_CLI_PRIO);
+}
+
+void nsh_commands_set_detach_quit(bool detach)
+{
+    g_detach_quit = detach;
+}
+
+int nsh_commands_run_interactive(void)
+{
+    cli_thread(NULL);
+    return OK;
 }

--- a/src/channels/nsh_commands.h
+++ b/src/channels/nsh_commands.h
@@ -40,3 +40,12 @@ int nsh_commands_init(void);
  * Call after all services are in a known state (post Phase 5).
  */
 int nsh_commands_start(void);
+
+/**
+ * Run CLI on the caller thread until the user types quit.
+ * Used when a --daemon agent is already running.
+ */
+int nsh_commands_run_interactive(void);
+
+/** When true, quit exits CLI only and leaves the daemon agent running. */
+void nsh_commands_set_detach_quit(bool detach);

--- a/src/core/agent_loop.c
+++ b/src/core/agent_loop.c
@@ -42,7 +42,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <sys/time.h>
+#include <time.h>
 
 #include "cJSON.h"
 
@@ -65,31 +65,33 @@ static bool llm_call_timed_out(uint32_t latency_ms);
 #define LLM_TIMEOUT_TASK_COMPLETE_MSG \
     "任务已完成，但生成确认消息超时。"
 
-/* ── Clock-safe elapsed time calculation ───────────────────── */
+/* ── Monotonic elapsed time (immune to wall-clock jumps) ───── */
 
-static inline uint32_t calc_elapsed_ms(const struct timeval* t0,
-    const struct timeval* t1)
+static inline void mono_now(struct timespec* ts)
 {
-    int32_t sec_diff = (int32_t)(t1->tv_sec - t0->tv_sec);
-    int32_t usec_diff = (int32_t)(t1->tv_usec - t0->tv_usec);
+    clock_gettime(CLOCK_MONOTONIC, ts);
+}
 
-    /* Clock went backwards (NTP jump, manual adjustment) */
+static inline uint32_t calc_elapsed_ms(const struct timespec* t0,
+    const struct timespec* t1)
+{
+    int64_t sec_diff = (int64_t)(t1->tv_sec - t0->tv_sec);
+    int64_t nsec_diff = (int64_t)(t1->tv_nsec - t0->tv_nsec);
+
     if (sec_diff < 0) {
-        syslog(LOG_WARNING, "[%s] Clock went backwards, ignoring\n", TAG);
         return 0;
     }
 
-    /* Microsecond borrow */
-    if (usec_diff < 0) {
+    if (nsec_diff < 0) {
         sec_diff--;
-        usec_diff += 1000000;
+        nsec_diff += 1000000000L;
     }
 
     if (sec_diff < 0) {
         return 0;
     }
 
-    return (uint32_t)sec_diff * 1000 + (uint32_t)usec_diff / 1000;
+    return (uint32_t)sec_diff * 1000 + (uint32_t)(nsec_diff / 1000000L);
 }
 
 /* ── Memory pool (pre-allocated tool output buffers) ───────── */
@@ -105,12 +107,12 @@ static void add_assistant_message(cJSON* messages, const llm_response_t* resp)
 
     if (resp->text && resp->text_len > 0) {
         cJSON_AddStringToObject(asst_msg, "content", resp->text);
-    } else {
-        cJSON_AddNullToObject(asst_msg, "content");
     }
+    /* Omit content when empty — MiMo rejects explicit null (400 Invalid JSON). */
 
-    /* Kimi thinking mode: echo back reasoning_content or the API returns 400 */
-    if (resp->reasoning_content && resp->reasoning_content[0]) {
+    /* Kimi thinking mode only — other hosts reject unknown fields. */
+    if (resp->reasoning_content && resp->reasoning_content[0]
+        && llm_proxy_echo_reasoning()) {
         cJSON_AddStringToObject(asst_msg, "reasoning_content",
             resp->reasoning_content);
     }
@@ -819,10 +821,10 @@ static char* force_finish_reply(const char* system_prompt,
 
     llm_response_t resp;
     char* result = NULL;
-    struct timeval t0, t1;
-    gettimeofday(&t0, NULL);
+    struct timespec t0, t1;
+    mono_now(&t0);
     int err = llm_chat_tools(system_prompt, messages, NULL, &resp);
-    gettimeofday(&t1, NULL);
+    mono_now(&t1);
     uint32_t ms = calc_elapsed_ms(&t0, &t1);
     bool timed_out = llm_call_timed_out(ms);
 
@@ -989,10 +991,10 @@ static char* handle_task_complete(const char* sys_prompt, cJSON* messages,
 
     llm_response_t final_resp;
     char* result = NULL;
-    struct timeval t0, t1;
-    gettimeofday(&t0, NULL);
+    struct timespec t0, t1;
+    mono_now(&t0);
     int err = llm_chat_tools(sys_prompt, messages, NULL, &final_resp);
-    gettimeofday(&t1, NULL);
+    mono_now(&t1);
     uint32_t ms = calc_elapsed_ms(&t0, &t1);
     bool timed_out = llm_call_timed_out(ms);
 
@@ -1064,10 +1066,10 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
         send_working_status(msg, iteration);
 
         llm_response_t resp;
-        struct timeval tv_start, tv_end;
-        gettimeofday(&tv_start, NULL);
+        struct timespec tv_start, tv_end;
+        mono_now(&tv_start);
         int err = llm_chat_tools(sys_prompt, messages, tools_json, &resp);
-        gettimeofday(&tv_end, NULL);
+        mono_now(&tv_end);
         uint32_t latency_ms = calc_elapsed_ms(&tv_start, &tv_end);
 
         /* Router failover: on LLM call failure, try next backend */
@@ -1083,10 +1085,10 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
                 router_idx = next_idx;
                 trace.backend_idx = next_idx;
                 llm_response_free(&resp);
-                gettimeofday(&tv_start, NULL);
+                mono_now(&tv_start);
                 err = llm_chat_tools(sys_prompt, messages,
                     tools_json, &resp);
-                gettimeofday(&tv_end, NULL);
+                mono_now(&tv_end);
                 latency_ms = calc_elapsed_ms(&tv_start, &tv_end);
             }
         }
@@ -1183,10 +1185,10 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
                     router_idx = prem_idx;
                     trace.backend_idx = prem_idx;
 
-                    gettimeofday(&tv_start, NULL);
+                    mono_now(&tv_start);
                     err = llm_chat_tools(sys_prompt, messages,
                         tools_json, &resp);
-                    gettimeofday(&tv_end, NULL);
+                    mono_now(&tv_end);
                     latency_ms = calc_elapsed_ms(&tv_start, &tv_end);
 
                     /* Watchdog check on cascade retry */
@@ -1261,6 +1263,8 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
         /* Local tool shortcut: if the single tool in this round is a
          * local file op, skip the next LLM round and use the tool
          * output directly as the reply. Saves ~2s.
+         * list_dir is excluded — it is almost always a discovery step
+         * before read_file / run_shell / write_file (e.g. Skill workflows).
          * Restricted to call_count == 1: the parallel path does not
          * write into tool_output, so multi-call rounds must go through
          * the LLM to aggregate results (and tool_output would be stale
@@ -1270,8 +1274,7 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
             for (int i = 0; i < resp.call_count; i++) {
                 if (strcmp(resp.calls[i].name, "read_file") != 0
                     && strcmp(resp.calls[i].name, "write_file") != 0
-                    && strcmp(resp.calls[i].name, "edit_file") != 0
-                    && strcmp(resp.calls[i].name, "list_dir") != 0) {
+                    && strcmp(resp.calls[i].name, "edit_file") != 0) {
                     all_local = false;
                     break;
                 }

--- a/src/llm/llm_proxy.c
+++ b/src/llm/llm_proxy.c
@@ -61,6 +61,37 @@ bool is_openai_compat_host(const char* host)
         || strstr(host, "xiaomimimo.com");
 }
 
+bool llm_proxy_echo_reasoning(void)
+{
+    char host[128];
+
+    pthread_mutex_lock(&s_llm_lock);
+    memcpy(host, s_llm_host, sizeof(host));
+    pthread_mutex_unlock(&s_llm_lock);
+
+    return strstr(host, "moonshot") != NULL
+        || strstr(host, "kimi") != NULL;
+}
+
+/* MiMo/OpenAI-compat: null content and unknown fields break the API. */
+static void llm_sanitize_messages_for_api(cJSON* msgs)
+{
+    cJSON* msg;
+
+    cJSON_ArrayForEach(msg, msgs)
+    {
+        cJSON* content = cJSON_GetObjectItem(msg, "content");
+
+        if (content && cJSON_IsNull(content)) {
+            cJSON_DeleteItemFromObject(msg, "content");
+        }
+
+        if (!llm_proxy_echo_reasoning()) {
+            cJSON_DeleteItemFromObject(msg, "reasoning_content");
+        }
+    }
+}
+
 
 int resp_buf_init(resp_buf_t* rb, size_t initial_cap)
 {
@@ -722,6 +753,7 @@ int llm_chat_tools(const char* system_prompt, cJSON* messages,
     cJSON_AddStringToObject(sys_msg, "role", "system");
     cJSON_AddStringToObject(sys_msg, "content", system_prompt);
     cJSON_InsertItemInArray(msgs, 0, sys_msg);
+    llm_sanitize_messages_for_api(msgs);
     cJSON_AddItemToObject(body, "messages", msgs);
 
     /* Convert tools to OpenAI format */

--- a/src/llm/llm_proxy.h
+++ b/src/llm/llm_proxy.h
@@ -78,6 +78,8 @@ int llm_chat_tools(const char* system_prompt,
     const char* tools_json,
     llm_response_t* resp);
 
+bool llm_proxy_echo_reasoning(void);
+
 /** Vision chat: send text + base64 image to a vision-capable model.
  *  image_b64 is the raw base64 string (no data: prefix).
  *  mime_type: "image/jpeg", "image/png", etc. NULL defaults to "image/jpeg". */

--- a/src/tools/tool_files.c
+++ b/src/tools/tool_files.c
@@ -38,6 +38,63 @@ static const char *TAG = "tool_files";
 
 #define MAX_FILE_SIZE (32 * 1024)
 
+/* VelaGuard reports/alarms live outside AGENT_DATA_DIR but on the same /data mount. */
+#define VG_DATA_ROOT "/data/velaguard"
+
+static bool path_under_resolved_root(const char *resolved, const char *logical_root)
+{
+    char root[PATH_MAX];
+    const char *base = logical_root;
+
+    if (realpath(logical_root, root) != NULL) {
+        base = root;
+    }
+
+    size_t len = strlen(base);
+    return strncmp(resolved, base, len) == 0
+        && (resolved[len] == '/' || resolved[len] == '\0');
+}
+
+static bool logical_path_allowed(const char *path)
+{
+    size_t agent_len = strlen(AGENT_DATA_DIR);
+
+    if (strncmp(path, AGENT_DATA_DIR, agent_len) == 0
+        && (path[agent_len] == '/' || path[agent_len] == '\0')) {
+        return true;
+    }
+
+    if (strncmp(path, VG_DATA_ROOT, sizeof(VG_DATA_ROOT) - 1) == 0
+        && (path[sizeof(VG_DATA_ROOT) - 1] == '/'
+            || path[sizeof(VG_DATA_ROOT) - 1] == '\0')) {
+        return true;
+    }
+
+    return false;
+}
+
+static bool path_has_prefix(const char *path, const char *prefix)
+{
+    if (!prefix || prefix[0] == '\0') {
+        return true;
+    }
+
+    size_t plen = strlen(prefix);
+    while (plen > 0 && prefix[plen - 1] == '/') {
+        plen--;
+    }
+
+    if (strlen(path) < plen) {
+        return false;
+    }
+
+    if (strncmp(path, prefix, plen) != 0) {
+        return false;
+    }
+
+    return path[plen] == '\0' || path[plen] == '/';
+}
+
 /**
  * Validate that path resolves to a location under AGENT_DATA_DIR.
  * Uses realpath() to resolve symlinks, preventing symlink escape attacks.
@@ -49,35 +106,27 @@ static bool validate_path(const char *path)
         return false;
     }
 
-    size_t dlen = strlen(AGENT_DATA_DIR);
-
-    /* Quick reject: raw path must at least start with data dir */
-    if (strncmp(path, AGENT_DATA_DIR, dlen) != 0
-        || (path[dlen] != '/' && path[dlen] != '\0')) {
-        return false;
-    }
-
     /* Reject explicit traversal components */
     if (strstr(path, "..") != NULL) {
         return false;
     }
 
-    /* Resolve symlinks to get the real path */
+    if (!logical_path_allowed(path)) {
+        return false;
+    }
+
+    /* Resolve symlinks (/data -> /mnt/emmc/data) and verify physical path. */
     char resolved[PATH_MAX];
 
     if (realpath(path, resolved) != NULL) {
-        /* File exists — verify resolved path is still under data dir */
-        if (strncmp(resolved, AGENT_DATA_DIR, dlen) != 0
-            || (resolved[dlen] != '/' && resolved[dlen] != '\0')) {
+        if (!path_under_resolved_root(resolved, AGENT_DATA_DIR)
+            && !path_under_resolved_root(resolved, VG_DATA_ROOT)) {
             syslog(LOG_WARNING,
-                   "[%s] Path escaped data dir via symlink: %s -> %s\n",
+                   "[%s] Path escaped allowed data dirs via symlink: %s -> %s\n",
                    TAG, path, resolved);
             return false;
         }
     }
-
-    /* If realpath fails (file doesn't exist yet), the raw path checks
-     * above are sufficient — no symlink to follow. */
 
     return true;
 }
@@ -115,10 +164,18 @@ static bool is_write_protected(const char *path)
 static void ensure_parent_dirs(const char *path)
 {
     char tmp[512];
+    size_t start;
+
     snprintf(tmp, sizeof(tmp), "%s", path);
 
-    /* Walk from the first '/' after AGENT_DATA_DIR to the last '/' */
-    size_t start = strlen(AGENT_DATA_DIR);
+    if (strncmp(path, AGENT_DATA_DIR, strlen(AGENT_DATA_DIR)) == 0) {
+        start = strlen(AGENT_DATA_DIR);
+    } else if (strncmp(path, VG_DATA_ROOT, sizeof(VG_DATA_ROOT) - 1) == 0) {
+        start = sizeof(VG_DATA_ROOT) - 1;
+    } else {
+        return;
+    }
+
     for (char *p = tmp + start; *p; p++) {
         if (*p == '/') {
             *p = '\0';
@@ -141,7 +198,8 @@ int tool_read_file_execute(const char *input_json, char *output, size_t output_s
     const char *path = cJSON_GetStringValue(cJSON_GetObjectItem(root, "path"));
     if (!validate_path(path)) {
         snprintf(output, output_size,
-                 "Error: path must start with %s/ and must not contain '..'", AGENT_DATA_DIR);
+                 "Error: path must be under %s/ or %s/ and must not contain '..'",
+                 AGENT_DATA_DIR, VG_DATA_ROOT);
         cJSON_Delete(root);
         return ERROR;
     }
@@ -180,7 +238,8 @@ int tool_write_file_execute(const char *input_json, char *output, size_t output_
 
     if (!validate_path(path)) {
         snprintf(output, output_size,
-                 "Error: path must start with %s/ and must not contain '..'", AGENT_DATA_DIR);
+                 "Error: path must be under %s/ or %s/ and must not contain '..'",
+                 AGENT_DATA_DIR, VG_DATA_ROOT);
         cJSON_Delete(root);
         return ERROR;
     }
@@ -239,7 +298,8 @@ int tool_edit_file_execute(const char *input_json, char *output, size_t output_s
 
     if (!validate_path(path)) {
         snprintf(output, output_size,
-                 "Error: path must start with %s/ and must not contain '..'", AGENT_DATA_DIR);
+                 "Error: path must be under %s/ or %s/ and must not contain '..'",
+                 AGENT_DATA_DIR, VG_DATA_ROOT);
         cJSON_Delete(root);
         return ERROR;
     }
@@ -347,7 +407,7 @@ static size_t list_dir_recursive(const char *dir_path, const char *prefix,
         char full_path[512];
         snprintf(full_path, sizeof(full_path), "%s/%s", dir_path, ent->d_name);
 
-        if (prefix && strncmp(full_path, prefix, strlen(prefix)) != 0) continue;
+        if (prefix && !path_has_prefix(full_path, prefix)) continue;
 
         struct stat st;
         if (stat(full_path, &st) == 0 && S_ISDIR(st.st_mode)) {

--- a/src/tools/tool_shell.c
+++ b/src/tools/tool_shell.c
@@ -90,7 +90,10 @@ static const char *s_allowed[] = {
     "set_gateway", "set_mqtt",
     "session_list", "memory_read",
     "mcp_list", "mcp_discover",
-    
+
+    /* VelaGuard read-only bring-up tools (stage1 ai_agent) */
+    "vgmodbus", "vgstats", "vgcfg", "vgnet",
+
     NULL
 };
 #endif
@@ -510,27 +513,31 @@ int tool_run_shell_execute(const char *input_json, char *output, size_t output_s
 
     cJSON_Delete(root);
 
-    if (ret != OK) {
-        snprintf(output, output_size, "{\"error\":\"Command failed: %s\"}", command);
+    /* Always return structured JSON so the LLM sees stdout even on non-zero exit. */
+    {
+        int exit_code = (ret == OK) ? 0 : 1;
+        cJSON *result = cJSON_CreateObject();
+
+        cJSON_AddNumberToObject(result, "exit_code", exit_code);
+        cJSON_AddStringToObject(result, "output", cmd_buf);
+        if (exit_code != 0) {
+            cJSON_AddStringToObject(result, "error", "non-zero exit");
+        }
+
+        char *json_str = cJSON_PrintUnformatted(result);
+        cJSON_Delete(result);
         free(cmd_buf);
-        return ERROR;
-    }
 
-    /* Build JSON result */
-    cJSON *result = cJSON_CreateObject();
-    cJSON_AddNumberToObject(result, "exit_code", 0);
-    cJSON_AddStringToObject(result, "output", cmd_buf);
-    free(cmd_buf);
+        if (!json_str) {
+            snprintf(output, output_size, "{\"exit_code\":1,\"output\":\"\"}");
+            return ERROR;
+        }
 
-    char *json_str = cJSON_PrintUnformatted(result);
-    cJSON_Delete(result);
-
-    if (json_str) {
         strncpy(output, json_str, output_size - 1);
         output[output_size - 1] = '\0';
-        syslog(LOG_INFO, "[%s] Result: %d bytes\n", TAG, (int)strlen(output));
         free(json_str);
+        syslog(LOG_INFO, "[%s] Result: %d bytes (exit=%d)\n",
+            TAG, (int)strlen(output), exit_code);
+        return OK;
     }
-
-    return OK;
 }


### PR DESCRIPTION
## Summary

Contest **Team Falcons / VelaGuard** board fixes for `packages/ai_agent` on STM32H750B-DK + eMMC `/data/agent`:

- **`--daemon` autostart** with NSH **attach** (no second full agent instance)
- **Monotonic clock** for LLM watchdog (avoids false timeout when TLS adjusts wall clock)
- **Wall clock seed** before HTTPS on boards without RTC
- **`tool_files`**: path checks against `realpath(AGENT_DATA_DIR)` for `/data` symlink layout
- **`run_shell`**: always return JSON `{exit_code, output}` even on non-zero exit
- **`llm_proxy`**: omit null assistant `content`; sanitize messages for MiMo API
- **`AGENT_LLM_TIMEOUT_SEC`**: 60 → 120 for multi-tool report flows

## Test plan

- [x] `bash scripts/build.sh net` (contest repo) links ai_agent
- [x] Board: autostart daemon + `nsh> ai_agent` attach → `vela> ask` operations_report daily report → `END status=ok`
- [x] Board: `read_file` / `write_file` under `/data/agent` and `/data/velaguard/reports`

## Contest

- Repo: https://github.com/FoLeaf/contest2026_004_TeamFalcons (`learn_vela`)
- Fork: https://github.com/FoLeaf/packages_ai_agent/tree/learn_vela


Made with [Cursor](https://cursor.com)