### PR TITLE
feat(remote-ctrl): drive a remote ACP agent from the device console

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,17 @@ if(CONFIG_EXAMPLES_AI_AGENT_VELA)
     )
   endif()
 
+  if(CONFIG_AI_AGENT_REMOTE_CTRL)
+    list(APPEND AGENT_SRCS
+      src/remote/remote_link.c
+      src/remote/remote_codec.c
+      src/remote/remote_session.c
+      src/remote/remote_link_mqtt.c
+      src/channels/remote_ctrl_channel.c
+      src/tools/tool_remote_agent.c
+    )
+  endif()
+
   if(CONFIG_AI_AGENT_BLE_GATT)
     list(APPEND AGENT_SRCS
       src/infra/ble_gatt.c

--- a/Kconfig
+++ b/Kconfig
@@ -189,6 +189,30 @@ config AI_AGENT_MCP
 		tool servers. Costs ~10KB RAM (registry + client state).
 		Disable to save memory if only using builtin tools.
 
+config AI_AGENT_REMOTE_CTRL
+	bool "Enable remote agent control channel"
+	default n
+	depends on NETUTILS_MQTTC && NETUTILS_CJSON
+	---help---
+		Let this device drive a remote ACP agent (mimocode or
+		kiro-cli) running on a PC, over a bridge that speaks MQTT
+		to the device. Adds the remote_agent_prompt and
+		remote_agent_status tools, the set_remote* config commands
+		and the r* console commands (rask, rstat, rreply, rusage,
+		ronce, rdeny).
+
+		Costs ~22KB RAM (12KB thread + 2x4.6KB MQTT buffers +
+		session state). Needs its own MQTT client, separate from
+		the AI_AGENT_MQTT chat channel, because each reconnect must
+		mint a new session nonce and redo the handshake.
+
+		Permission decisions for the remote agent are reachable only
+		from the NSH commands, never as an LLM-callable tool.
+
+		Broker address and credentials are supplied at runtime
+		through the config store (remote_broker, remote_username,
+		remote_password) and are never compiled in.
+
 config AI_AGENT_TEST
 	bool "Enable integration test commands"
 	default n

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,16 @@ ifeq ($(CONFIG_AI_AGENT_MQTT),y)
 CSRCS += src/channels/mqtt_channel.c
 endif
 
+# remote/ - 远程 ACP Agent 控制（设备作为客户端连接 PC 侧 bridge）
+ifeq ($(CONFIG_AI_AGENT_REMOTE_CTRL),y)
+CSRCS += src/remote/remote_link.c
+CSRCS += src/remote/remote_codec.c
+CSRCS += src/remote/remote_session.c
+CSRCS += src/remote/remote_link_mqtt.c
+CSRCS += src/channels/remote_ctrl_channel.c
+CSRCS += src/tools/tool_remote_agent.c
+endif
+
 CSRCS += src/channels/ws_server.c
 
 # voice/ - 语音管线

--- a/include/agent_config.h
+++ b/include/agent_config.h
@@ -327,6 +327,22 @@
 #define AGENT_CFG_KEY_MQTT_USERNAME "mqtt_username"
 #define AGENT_CFG_KEY_MQTT_PASSWORD "mqtt_password"
 
+/* ── Remote-control channel (drives a remote ACP agent) ─────── */
+#define AGENT_REMOTE_CTRL_STACK (12 * 1024)
+#define AGENT_REMOTE_CTRL_PRIO 45
+
+/* Default budget for one remote turn. A turn held up by a permission request
+ * cannot finish until a human answers on this device, so the tool reports what
+ * it has rather than waiting indefinitely. */
+#define AGENT_REMOTE_CTRL_TURN_TIMEOUT_MS 120000
+
+/* Credentials are read from the config store, never from a command line. */
+#define AGENT_CFG_KEY_REMOTE_BROKER "remote_broker"
+#define AGENT_CFG_KEY_REMOTE_DEVICE_ID "remote_device_id"
+#define AGENT_CFG_KEY_REMOTE_USERNAME "remote_username"
+#define AGENT_CFG_KEY_REMOTE_PASSWORD "remote_password"
+#define AGENT_CFG_KEY_REMOTE_TOPIC_PREFIX "remote_topic_prefix"
+
 /* ── Voice Channel (Doubao ASR/TTS) ─────────────────────────── */
 #define AGENT_CHAN_VOICE "voice"
 

--- a/src/agent_main.c
+++ b/src/agent_main.c
@@ -52,6 +52,9 @@
 #ifdef CONFIG_AI_AGENT_MQTT
 #include "channels/mqtt_channel.h"
 #endif
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+#include "channels/remote_ctrl_channel.h"
+#endif
 #include "infra/network_manager.h"
 #ifdef CONFIG_AI_AGENT_NODE
 #include "node/node_client.h"
@@ -127,6 +130,9 @@ static void net_state_change_cb(net_state_t state, void* arg)
 #ifdef CONFIG_AI_AGENT_MQTT
         mqtt_channel_start();
 #endif
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+        remote_ctrl_channel_start();
+#endif
 #ifdef CONFIG_AI_AGENT_WEIXIN
         weixin_channel_start();
 #endif
@@ -177,6 +183,10 @@ static void* network_watch_task(void* arg)
 #ifdef CONFIG_AI_AGENT_MQTT
         if (mqtt_channel_start() != OK)
             syslog(LOG_WARNING, "[%s] mqtt_channel_start failed\n", TAG);
+#endif
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+        if (remote_ctrl_channel_start() != OK)
+            syslog(LOG_WARNING, "[%s] remote_ctrl_channel_start failed\n", TAG);
 #endif
 #ifdef CONFIG_AI_AGENT_WEIXIN
         if (weixin_channel_start() != OK)
@@ -585,6 +595,11 @@ int ai_agent_main(int argc, char* argv[])
         BOOT_LOG_RC(&t0, "P3", "mqtt_channel_init", rc);
 #endif
 
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+        rc = remote_ctrl_channel_init();
+        BOOT_LOG_RC(&t0, "P3", "remote_ctrl_channel_init", rc);
+#endif
+
         rc = voice_channel_init();
         BOOT_LOG_RC(&t0, "P3", "voice_channel_init", rc);
 
@@ -721,6 +736,9 @@ int ai_agent_main(int argc, char* argv[])
 #endif
 #ifdef CONFIG_AI_AGENT_MQTT
     mqtt_channel_stop();
+#endif
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+    remote_ctrl_channel_stop();
 #endif
     ws_server_stop();
     /* feishu_bot and agent_loop have no _stop(); they will exit

--- a/src/channels/cmd_channel.c
+++ b/src/channels/cmd_channel.c
@@ -18,6 +18,9 @@
 #include "infra/config_store.h"
 #include "channels/feishu_bot.h"
 #include "channels/mqtt_channel.h"
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+#include "channels/remote_ctrl_channel.h"
+#endif
 #ifdef CONFIG_AI_AGENT_NODE
 #include "node/node_client.h"
 #include "node/node_manager.h"
@@ -163,3 +166,272 @@ void cmd_weixin_login(void)
     }
     printf("Timeout waiting for scan.\n");
 }
+
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+
+/* The transcript is up to 8 KiB and the console thread has a 16 KiB stack, so
+ * it is staged here rather than on the stack. Only the console reads it. */
+static char g_remote_text[REMOTE_TRANSCRIPT_MAX + 1];
+
+void cmd_set_remote(int argc, char** argv)
+{
+    if (argc < 2) {
+        printf("Usage: set_remote <host:port> [device_id]\n"
+               "  Points this device at the PC bridge that fronts the remote\n"
+               "  agent. Use set_remote_auth for broker credentials.\n");
+        return;
+    }
+
+    claw_config_set(AGENT_CFG_KEY_REMOTE_BROKER, argv[1]);
+    if (argc >= 3) {
+        claw_config_set(AGENT_CFG_KEY_REMOTE_DEVICE_ID, argv[2]);
+    }
+
+    /* Re-init and start immediately so no restart is needed. */
+    remote_ctrl_channel_stop();
+    remote_ctrl_channel_init();
+    if (remote_ctrl_channel_start() != OK) {
+        printf("Remote broker saved, but the channel did not start. "
+               "Check the log.\n");
+        return;
+    }
+
+    printf("Remote broker set to %s and starting.\n", argv[1]);
+}
+
+void cmd_set_remote_auth(int argc, char** argv)
+{
+    if (argc < 3) {
+        printf("Usage: set_remote_auth <username> <password>\n");
+        return;
+    }
+
+    claw_config_set(AGENT_CFG_KEY_REMOTE_USERNAME, argv[1]);
+    claw_config_set(AGENT_CFG_KEY_REMOTE_PASSWORD, argv[2]);
+
+    remote_ctrl_channel_stop();
+    remote_ctrl_channel_init();
+    remote_ctrl_channel_start();
+
+    /* The password is never echoed. */
+    printf("Remote credentials saved for %s.\n", argv[1]);
+}
+
+void cmd_remote_status(void)
+{
+    struct remote_status_s status;
+
+    if (remote_ctrl_channel_status(&status) != OK) {
+        printf("Remote control is not configured. Use set_remote first.\n");
+        return;
+    }
+
+    printf("=== Remote agent ===\n");
+    printf("  State     : %s\n", remote_state_name(status.state));
+    if (status.summary[0] != '\0') {
+        printf("  Activity  : %s\n", status.summary);
+    }
+    /* Which model answered matters for reading the reply and the bill, and it
+     * can be changed from the PC side, so it is shown rather than assumed. */
+    if (status.model[0] != '\0') {
+        printf("  Model     : %s\n", status.model);
+    }
+    if (status.billing[0] != '\0') {
+        printf("  %s\n", status.billing);
+    }
+    printf("  Chat turns: %s\n", status.chat_supported ? "yes" : "no");
+    if (status.turn_active) {
+        printf("  A turn is running.\n");
+    }
+
+    if (status.has_prompt) {
+        printf("\n  Approval needed for: %s\n", status.prompt.tool);
+        if (status.prompt.hint[0] != '\0') {
+            printf("  Details            : %s\n", status.prompt.hint);
+        }
+        if (status.decision_in_flight) {
+            printf("  A decision was already sent; waiting for the bridge.\n");
+        } else {
+            printf("  Answer with%s%s.\n",
+                status.prompt.can_once ? " 'ronce'" : "",
+                status.prompt.can_deny
+                    ? (status.prompt.can_once ? " or 'rdeny'" : " 'rdeny'")
+                    : "");
+        }
+    }
+    printf("====================\n");
+}
+
+void cmd_remote_ask(int argc, char** argv)
+{
+    char text[REMOTE_PROMPT_TEXT_MAX + 1] = { 0 };
+    char reply[256];
+
+    if (argc < 2) {
+        printf("Usage: rask <instruction>\n");
+        return;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        strncat(text, argv[i], sizeof(text) - strlen(text) - 1);
+        if (i < argc - 1) {
+            strncat(text, " ", sizeof(text) - strlen(text) - 1);
+        }
+    }
+
+    /* Non-blocking on purpose: if this waited for the turn, a remote permission
+     * request could never be answered, because answering it needs this very
+     * console. */
+    if (remote_ctrl_channel_submit(text, reply, sizeof(reply)) != OK) {
+        printf("%s\n", reply);
+        return;
+    }
+
+    printf("%s\n", reply);
+}
+
+void cmd_remote_output(void)
+{
+    if (remote_ctrl_channel_transcript(g_remote_text, sizeof(g_remote_text)) != OK) {
+        printf("Remote control is not configured.\n");
+        return;
+    }
+
+    if (g_remote_text[0] == '\0') {
+        printf("(no remote agent output yet)\n");
+        return;
+    }
+
+    printf("%s", g_remote_text);
+    if (g_remote_text[strlen(g_remote_text) - 1] != '\n') {
+        printf("\n");
+    }
+}
+
+/* Resolves a console argument to a model name. All digits means the number the
+ * listing printed; anything else is taken as a name, so a model the device could
+ * not remember — the list is bounded and may be truncated — is still reachable
+ * by typing it in full. Returns NULL only for a number outside the list. */
+static const char* resolve_model(const struct remote_model_view_s* view,
+    const char* argument)
+{
+    size_t index = 0;
+    size_t i;
+
+    for (i = 0; argument[i] != '\0'; i++) {
+        if (argument[i] < '0' || argument[i] > '9') {
+            return argument;
+        }
+
+        /* Digits only: the user meant an index, so an out-of-range one is an
+         * error rather than a name to forward. Bounded here so a long run of
+         * digits cannot overflow on the way to that check. */
+        if (index > REMOTE_MODEL_OPTIONS_MAX) {
+            return NULL;
+        }
+        index = index * 10 + (size_t)(argument[i] - '0');
+    }
+
+    if (index == 0 || index > view->count) {
+        return NULL;
+    }
+
+    return view->options[index - 1];
+}
+
+void cmd_remote_model(int argc, char** argv)
+{
+    /* Static because the view carries the whole option table: too large for this
+     * thread's stack, and copying it out beats holding the session lock across a
+     * screenful of printf calls to a slow console. */
+    static struct remote_model_view_s view;
+    const char* target;
+    uint8_t i;
+
+    if (remote_ctrl_channel_model_view(&view) != OK) {
+        printf("Remote control is not configured.\n");
+        return;
+    }
+
+    if (argc < 2) {
+        if (view.current[0] == '\0') {
+            printf("Model: unknown — the bridge has not reported one yet.\n");
+        } else {
+            printf("Model: %s\n", view.current);
+        }
+
+        if (view.count == 0) {
+            printf("No selectable models reported yet.\n");
+            return;
+        }
+
+        printf("Switch with 'rmodel <number>' or 'rmodel <name>':\n");
+        for (i = 0; i < view.count; i++) {
+            printf("  %2u  %s%s\n", (unsigned)(i + 1), view.options[i],
+                strcmp(view.options[i], view.current) == 0 ? "   (current)" : "");
+        }
+
+        if (view.truncated) {
+            printf("List is partial; a name missing from it may still be "
+                   "accepted.\n");
+        }
+        return;
+    }
+
+    target = resolve_model(&view, argv[1]);
+    if (target == NULL) {
+        printf("No model %s in the list. Run 'rmodel' to see it.\n", argv[1]);
+        return;
+    }
+
+    /* Checked before sending only to give a clear reason; the link refuses this
+     * on its own, and the bridge refuses it again. */
+    if (view.turn_active) {
+        printf("A turn is running. Wait for it to finish, then switch.\n");
+        return;
+    }
+
+    if (remote_ctrl_channel_select_model(target) != OK) {
+        printf("Could not request '%s': the link is offline, a turn is "
+               "running, or the name is unusable.\n", target);
+        return;
+    }
+
+    printf("Requested '%s'. The bridge decides whether it applies; 'rstat' "
+           "shows what took effect.\n", target);
+}
+
+void cmd_remote_usage(void)
+{
+    if (remote_ctrl_channel_query_usage() != OK) {
+        printf("Could not query usage: the link is offline or unconfigured.\n");
+        return;
+    }
+
+    printf("Usage query sent; the refreshed value appears in the log and in "
+           "'rstat'.\n");
+}
+
+void cmd_remote_once(void)
+{
+    if (remote_ctrl_channel_decide(REMOTE_DECISION_ONCE) != OK) {
+        printf("No approvable request is pending (or one was already "
+               "answered).\n");
+        return;
+    }
+
+    printf("Approved once.\n");
+}
+
+void cmd_remote_deny(void)
+{
+    if (remote_ctrl_channel_decide(REMOTE_DECISION_DENY) != OK) {
+        printf("No deniable request is pending (or one was already "
+               "answered).\n");
+        return;
+    }
+
+    printf("Denied.\n");
+}
+
+#endif /* CONFIG_AI_AGENT_REMOTE_CTRL */

--- a/src/channels/cmd_channel.h
+++ b/src/channels/cmd_channel.h
@@ -29,3 +29,22 @@ void cmd_node_stop(void);
 void cmd_set_gateway(int argc, char** argv);
 void cmd_set_weixin_token(int argc, char** argv);
 void cmd_weixin_login(void);
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+void cmd_set_remote(int argc, char** argv);
+void cmd_set_remote_auth(int argc, char** argv);
+void cmd_remote_status(void);
+void cmd_remote_ask(int argc, char** argv);
+void cmd_remote_output(void);
+void cmd_remote_usage(void);
+
+/* No argument lists the models; an argument selects one, by list number or by
+ * name. Safe for a model to call in principle, but kept console-only for now so
+ * the r* family stays one thing: commands a person types. */
+void cmd_remote_model(int argc, char** argv);
+
+/* Permission decisions for the remote agent. These exist only as console
+ * commands (and later a GPIO key): they are the human half of the protocol and
+ * are deliberately absent from the tool registry. */
+void cmd_remote_once(void);
+void cmd_remote_deny(void);
+#endif

--- a/src/channels/nsh_commands.c
+++ b/src/channels/nsh_commands.c
@@ -124,6 +124,21 @@ static void cmd_help(void)
         "  node_start          - Connect to OpenClaw Gateway as Node\n"
         "  node_stop           - Disconnect from OpenClaw Gateway\n"
 #endif
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+        "  set_remote <host:port> [device_id] - Set PC bridge for remote agent\n"
+        "  set_remote_auth <user> <pass> - Set bridge broker credentials\n"
+        /* One 'r' prefix for the whole family: these are typed at a console, and
+         * a set where one name is short and the rest are long is worse than
+         * either convention on its own. set_remote* keep their names because
+         * they follow the repo-wide set_<thing> pattern for configuration. */
+        "  rask <text>          - Send one instruction to the remote agent\n"
+        "  rstat                - Remote agent state, model, billing, approval\n"
+        "  rreply               - Print the remote agent's full reply\n"
+        "  rmodel [n|name]      - List remote agent models, or switch to one\n"
+        "  rusage               - Refresh remote session billing\n"
+        "  ronce                - Approve the pending request (human only)\n"
+        "  rdeny                - Deny the pending request (human only)\n"
+#endif
         "  restart              - Restart the device\n"
         "  quit                 - Exit agent\n"
         "  set_mqtt <broker> [client_id] - Set MQTT broker (host:port)\n"
@@ -480,6 +495,12 @@ static void cmd_config_show(void)
     SHOW_CFG("GW Port", AGENT_CFG_KEY_GATEWAY_PORT, false);
     SHOW_CFG("GW Token", AGENT_CFG_KEY_GATEWAY_TOKEN, true);
     SHOW_CFG("MQTT Broker", AGENT_CFG_KEY_MQTT_BROKER, false);
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+    SHOW_CFG("Remote Broker", AGENT_CFG_KEY_REMOTE_BROKER, false);
+    SHOW_CFG("Remote Device", AGENT_CFG_KEY_REMOTE_DEVICE_ID, false);
+    SHOW_CFG("Remote User", AGENT_CFG_KEY_REMOTE_USERNAME, false);
+    SHOW_CFG("Remote Pass", AGENT_CFG_KEY_REMOTE_PASSWORD, true);
+#endif
     SHOW_CFG("Volc AppKey", AGENT_CFG_KEY_VOLC_APPKEY, true);
     SHOW_CFG("Volc Token", AGENT_CFG_KEY_VOLC_TOKEN, true);
     SHOW_CFG("Volc API Key", AGENT_CFG_KEY_VOLC_API_KEY, true);
@@ -986,6 +1007,29 @@ static void* cli_thread(void* arg)
             cmd_node_start();
         else if (strcmp(cmd, "node_stop") == 0)
             cmd_node_stop();
+#endif
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+        else if (strcmp(cmd, "set_remote") == 0)
+            cmd_set_remote(argc, argv);
+        else if (strcmp(cmd, "set_remote_auth") == 0)
+            cmd_set_remote_auth(argc, argv);
+        /* One spelling each, all 'r'-prefixed (see the help block for why).
+         * A second name for the same action would only be one more thing to
+         * remember and one more place to fall out of date. */
+        else if (strcmp(cmd, "rask") == 0)
+            cmd_remote_ask(argc, argv);
+        else if (strcmp(cmd, "rstat") == 0)
+            cmd_remote_status();
+        else if (strcmp(cmd, "rreply") == 0)
+            cmd_remote_output();
+        else if (strcmp(cmd, "rmodel") == 0)
+            cmd_remote_model(argc, argv);
+        else if (strcmp(cmd, "rusage") == 0)
+            cmd_remote_usage();
+        else if (strcmp(cmd, "ronce") == 0)
+            cmd_remote_once();
+        else if (strcmp(cmd, "rdeny") == 0)
+            cmd_remote_deny();
 #endif
         else if (strcmp(cmd, "quit") == 0) {
             cmd_quit();

--- a/src/channels/remote_ctrl_channel.c
+++ b/src/channels/remote_ctrl_channel.c
@@ -1,0 +1,477 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "channels/remote_ctrl_channel.h"
+
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+
+#include "agent_config.h"
+#include "infra/config_store.h"
+#include "remote/remote_link_mqtt.h"
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+static const char* TAG = "remote_ctrl";
+
+/* ── State ─────────────────────────────────────────────────────────── */
+
+static struct remote_session_s g_session;
+
+static char g_broker_host[REMOTE_MQTT_HOST_MAX + 1];
+static char g_broker_port[REMOTE_MQTT_PORT_MAX + 1];
+static char g_username[REMOTE_MQTT_USER_MAX + 1];
+static char g_password[REMOTE_MQTT_PASSWORD_MAX + 1];
+static char g_device_id[REMOTE_MQTT_DEVICE_ID_MAX + 1];
+static char g_topic_prefix[REMOTE_MQTT_TOPIC_PREFIX_MAX + 1];
+
+static bool g_configured;
+static bool g_started;
+
+/* Turn completion, separate from the session's own lock.
+ *
+ * Lock order is one-way: the event handler runs with the session lock held and
+ * then takes g_turn_lock, so no path may hold g_turn_lock while calling into
+ * the session. remote_ctrl_channel_prompt() therefore arms the wait, submits
+ * with no lock held, and only then blocks. */
+static pthread_mutex_t g_turn_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t g_turn_cond = PTHREAD_COND_INITIALIZER;
+static bool g_turn_pending;
+static bool g_turn_finished;
+
+/* ── Event handler ─────────────────────────────────────────────────── */
+
+/* Invoked by the session with its lock held: keep this cheap and never call
+ * back into remote_session_*. */
+static void on_session_event(void* context, enum remote_event_e event,
+    const char* text)
+{
+    (void)context;
+
+    switch (event) {
+    case REMOTE_EVENT_STATE:
+        /* A status line and nothing else: what the agent is doing, never what it
+         * said. The bridge holds to the same rule on its side, so this reports
+         * "Agent working", a tool name, or "Agent replying" — the reply itself
+         * arrives as REMOTE_EVENT_TURN_TRANSCRIPT once the turn ends. */
+        syslog(LOG_INFO, "[%s] status: %s\n", TAG, text != NULL ? text : "");
+        break;
+
+    case REMOTE_EVENT_AGENT_OUTPUT:
+        /* Deliberately silent. A chunk lands every few tens of milliseconds and
+         * splits mid-sentence, so logging one line per chunk filled the console
+         * without saying anything the 'Agent replying' status line above has not
+         * already said. The link accumulates them; the reply prints once, below. */
+        break;
+
+    case REMOTE_EVENT_TURN_TRANSCRIPT:
+        /* One call for the whole reply, not one per line. nx_vsyslog stamps its
+         * prefix once per call, so printing line by line turned a reply into a
+         * column of timestamped log records; passing the text in one go lets its
+         * own newlines through and it reads as the block it is.
+         *
+         * No trailing newline here: nx_vsyslog appends one when the text does not
+         * already end in it, so adding one would leave a blank line behind every
+         * reply. Length is not a concern — CONFIG_SYSLOG_BUFFER is off on this
+         * board, so the raw stream writes straight through with no fixed buffer
+         * to truncate against. */
+        syslog(LOG_INFO, "[%s] reply:\n%s", TAG, text != NULL ? text : "");
+        break;
+
+    case REMOTE_EVENT_OUTPUT_GAP:
+        syslog(LOG_WARNING, "[%s] agent output may be incomplete\n", TAG);
+        break;
+
+    case REMOTE_EVENT_MODEL:
+        /* Announced because it can change from the PC side too, and which model
+         * answered a prompt is worth knowing without polling 'rstat'. */
+        syslog(LOG_INFO, "[%s] model: %s\n", TAG, text != NULL ? text : "");
+        break;
+
+    case REMOTE_EVENT_PROMPT_REJECTED:
+        pthread_mutex_lock(&g_turn_lock);
+        g_turn_finished = true;
+        pthread_cond_broadcast(&g_turn_cond);
+        pthread_mutex_unlock(&g_turn_lock);
+        syslog(LOG_WARNING, "[%s] prompt rejected by bridge\n", TAG);
+        break;
+
+    case REMOTE_EVENT_TURN_RESULT:
+        pthread_mutex_lock(&g_turn_lock);
+        g_turn_finished = true;
+        pthread_cond_broadcast(&g_turn_cond);
+        pthread_mutex_unlock(&g_turn_lock);
+        syslog(LOG_INFO, "[%s] %s\n", TAG, text != NULL ? text : "turn ended");
+        break;
+
+    case REMOTE_EVENT_BILLING:
+        syslog(LOG_INFO, "[%s] %s\n", TAG, text != NULL ? text : "");
+        break;
+
+    default:
+        break;
+    }
+}
+
+/* ── Configuration ─────────────────────────────────────────────────── */
+
+/* Splits "host" or "host:port"; the port defaults to the MQTT standard. */
+static void parse_broker(const char* broker)
+{
+    const char* colon = strrchr(broker, ':');
+    size_t host_length;
+
+    if (colon != NULL && colon != broker) {
+        host_length = (size_t)(colon - broker);
+        if (host_length > REMOTE_MQTT_HOST_MAX) {
+            host_length = REMOTE_MQTT_HOST_MAX;
+        }
+        memcpy(g_broker_host, broker, host_length);
+        g_broker_host[host_length] = '\0';
+        snprintf(g_broker_port, sizeof(g_broker_port), "%.*s",
+            (int)sizeof(g_broker_port) - 1, colon + 1);
+    } else {
+        snprintf(g_broker_host, sizeof(g_broker_host), "%s", broker);
+        snprintf(g_broker_port, sizeof(g_broker_port), "%d",
+            AGENT_MQTT_DEFAULT_PORT);
+    }
+}
+
+/* ── Transport thread ──────────────────────────────────────────────── */
+
+static void* transport_task(void* arg)
+{
+    struct remote_mqtt_config_s config;
+
+    (void)arg;
+
+    memset(&config, 0, sizeof(config));
+    config.host = g_broker_host;
+    config.port = g_broker_port;
+    config.username = g_username;
+    config.password = g_password;
+    config.device_id = g_device_id;
+    config.topic_prefix = g_topic_prefix[0] != '\0' ? g_topic_prefix : NULL;
+
+    /* Blocks until remote_ctrl_channel_stop(). */
+    remote_link_mqtt_run(&config, &g_session);
+    return NULL;
+}
+
+/* ── Lifecycle ─────────────────────────────────────────────────────── */
+
+int remote_ctrl_channel_init(void)
+{
+    char broker[REMOTE_MQTT_HOST_MAX + REMOTE_MQTT_PORT_MAX + 2];
+
+    memset(broker, 0, sizeof(broker));
+    memset(g_broker_host, 0, sizeof(g_broker_host));
+    memset(g_broker_port, 0, sizeof(g_broker_port));
+    memset(g_username, 0, sizeof(g_username));
+    memset(g_password, 0, sizeof(g_password));
+    memset(g_device_id, 0, sizeof(g_device_id));
+    memset(g_topic_prefix, 0, sizeof(g_topic_prefix));
+    g_configured = false;
+    g_started = false;
+
+    /* Credentials come from the config store, never from argv: a password in a
+     * command line is visible in the process list. */
+    claw_config_get(AGENT_CFG_KEY_REMOTE_BROKER, broker, sizeof(broker));
+    claw_config_get(AGENT_CFG_KEY_REMOTE_DEVICE_ID, g_device_id,
+        sizeof(g_device_id));
+    claw_config_get(AGENT_CFG_KEY_REMOTE_USERNAME, g_username,
+        sizeof(g_username));
+    claw_config_get(AGENT_CFG_KEY_REMOTE_PASSWORD, g_password,
+        sizeof(g_password));
+    claw_config_get(AGENT_CFG_KEY_REMOTE_TOPIC_PREFIX, g_topic_prefix,
+        sizeof(g_topic_prefix));
+
+    /* The session is usable before any link exists: it simply reports Offline
+     * and refuses every outbound operation. */
+    remote_session_init(&g_session, "");
+    remote_session_set_event_handler(&g_session, on_session_event, NULL);
+
+    if (broker[0] == '\0') {
+        syslog(LOG_INFO, "[%s] no remote_broker configured, channel idle\n",
+            TAG);
+        return OK;
+    }
+
+    if (g_device_id[0] == '\0') {
+        snprintf(g_device_id, sizeof(g_device_id), "%s", AGENT_NODE_ID);
+    }
+
+    parse_broker(broker);
+    g_configured = true;
+
+    syslog(LOG_INFO, "[%s] initialized (broker=%s:%s device=%s)\n", TAG,
+        g_broker_host, g_broker_port, g_device_id);
+    return OK;
+}
+
+int remote_ctrl_channel_start(void)
+{
+    int ret;
+
+    if (!g_configured) {
+        return OK;
+    }
+
+    if (g_started) {
+        return OK;
+    }
+
+    ret = agent_task_create(transport_task, "remote_ctrl",
+        AGENT_REMOTE_CTRL_STACK, NULL, AGENT_REMOTE_CTRL_PRIO);
+    if (ret != OK) {
+        syslog(LOG_ERR, "[%s] failed to create transport thread\n", TAG);
+        return ERROR;
+    }
+
+    g_started = true;
+    syslog(LOG_INFO, "[%s] started\n", TAG);
+    return OK;
+}
+
+void remote_ctrl_channel_stop(void)
+{
+    if (!g_started) {
+        return;
+    }
+
+    remote_link_mqtt_stop();
+    g_started = false;
+
+    /* Release anyone blocked in remote_ctrl_channel_prompt(). */
+    pthread_mutex_lock(&g_turn_lock);
+    g_turn_finished = true;
+    pthread_cond_broadcast(&g_turn_cond);
+    pthread_mutex_unlock(&g_turn_lock);
+
+    syslog(LOG_INFO, "[%s] stop requested\n", TAG);
+}
+
+bool remote_ctrl_channel_enabled(void)
+{
+    return g_configured;
+}
+
+/* ── Operations ────────────────────────────────────────────────────── */
+
+int remote_ctrl_channel_status(struct remote_status_s* out)
+{
+    if (out == NULL || !g_configured) {
+        return ERROR;
+    }
+
+    remote_session_status(&g_session, out);
+    return OK;
+}
+
+int remote_ctrl_channel_query_usage(void)
+{
+    if (!g_configured) {
+        return ERROR;
+    }
+
+    return remote_session_query_usage(&g_session) ? OK : ERROR;
+}
+
+int remote_ctrl_channel_model_view(struct remote_model_view_s* out)
+{
+    if (out == NULL || !g_configured) {
+        return ERROR;
+    }
+
+    remote_session_model_view(&g_session, out);
+    return OK;
+}
+
+int remote_ctrl_channel_select_model(const char* model)
+{
+    if (model == NULL || !g_configured) {
+        return ERROR;
+    }
+
+    return remote_session_select_model(&g_session, model) ? OK : ERROR;
+}
+
+int remote_ctrl_channel_decide(enum remote_decision_e decision)
+{
+    if (!g_configured) {
+        return ERROR;
+    }
+
+    return remote_session_decide(&g_session, decision) ? OK : ERROR;
+}
+
+/* Turns a refused submit into something a person or a model can act on. The
+ * session refuses for several distinct reasons and they need different
+ * responses, so "failed" on its own would be useless. */
+static void describe_submit_failure(char* out, size_t out_size)
+{
+    struct remote_status_s status;
+
+    remote_session_status(&g_session, &status);
+
+    if (status.state == REMOTE_STATE_OFFLINE) {
+        snprintf(out, out_size, "Error: remote agent link is offline");
+    } else if (status.has_prompt) {
+        snprintf(out, out_size,
+            "Error: the remote agent is waiting for a permission decision on "
+            "this device; answer it before sending a new prompt");
+    } else if (status.turn_active) {
+        snprintf(out, out_size, "Error: a remote turn is already running");
+    } else if (!status.chat_supported) {
+        snprintf(out, out_size,
+            "Error: the remote bridge does not offer chat turns");
+    } else {
+        snprintf(out, out_size, "Error: prompt rejected locally");
+    }
+}
+
+int remote_ctrl_channel_submit(const char* text, char* out, size_t out_size)
+{
+    if (text == NULL || out == NULL || out_size == 0) {
+        return ERROR;
+    }
+
+    if (!g_configured) {
+        snprintf(out, out_size, "Error: remote control is not configured");
+        return ERROR;
+    }
+
+    /* Deliberately does not touch the blocking-wait state: the session's own
+     * turn reservation is what keeps two turns from overlapping, and nothing
+     * would clear a wait that no one is performing. */
+    if (!remote_session_submit_prompt(&g_session, text)) {
+        describe_submit_failure(out, out_size);
+        return ERROR;
+    }
+
+    snprintf(out, out_size,
+        "Prompt sent. Use 'rstat' for progress; the reply prints in one piece "
+        "when the turn ends, and 'rreply' re-reads it.");
+    return OK;
+}
+
+int remote_ctrl_channel_transcript(char* out, size_t out_size)
+{
+    if (out == NULL || out_size == 0 || !g_configured) {
+        return ERROR;
+    }
+
+    return remote_session_transcript(&g_session, out, out_size) ? OK : ERROR;
+}
+
+int remote_ctrl_channel_prompt(const char* text, uint32_t timeout_ms,
+    char* out, size_t out_size)
+{
+    struct timespec deadline;
+    bool finished;
+    int ret = OK;
+
+    if (text == NULL || out == NULL || out_size == 0) {
+        return ERROR;
+    }
+
+    if (!g_configured) {
+        snprintf(out, out_size, "Error: remote control is not configured");
+        return ERROR;
+    }
+
+    /* Only one caller may own the turn slot at a time. The session would refuse
+     * a second submit anyway; rejecting here keeps the waiters unambiguous. */
+    pthread_mutex_lock(&g_turn_lock);
+    if (g_turn_pending) {
+        pthread_mutex_unlock(&g_turn_lock);
+        snprintf(out, out_size, "Error: a remote turn is already in progress");
+        return ERROR;
+    }
+    /* Armed before submitting so a turn that completes immediately cannot be
+     * missed between the submit and the wait. */
+    g_turn_pending = true;
+    g_turn_finished = false;
+    pthread_mutex_unlock(&g_turn_lock);
+
+    if (!remote_session_submit_prompt(&g_session, text)) {
+        pthread_mutex_lock(&g_turn_lock);
+        g_turn_pending = false;
+        pthread_mutex_unlock(&g_turn_lock);
+
+        describe_submit_failure(out, out_size);
+        return ERROR;
+    }
+
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += (time_t)(timeout_ms / 1000);
+    deadline.tv_nsec += (long)(timeout_ms % 1000) * 1000000L;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec += 1;
+        deadline.tv_nsec -= 1000000000L;
+    }
+
+    pthread_mutex_lock(&g_turn_lock);
+    while (!g_turn_finished) {
+        if (pthread_cond_timedwait(&g_turn_cond, &g_turn_lock, &deadline) == ETIMEDOUT) {
+            break;
+        }
+    }
+    finished = g_turn_finished;
+    g_turn_pending = false;
+    pthread_mutex_unlock(&g_turn_lock);
+
+    if (!remote_session_transcript(&g_session, out, out_size)) {
+        snprintf(out, out_size,
+            "Error: remote agent output does not fit the tool buffer");
+        return ERROR;
+    }
+
+    if (!finished) {
+        struct remote_status_s status;
+
+        remote_session_status(&g_session, &status);
+
+        /* A turn stalled on a permission request is an expected outcome, not a
+         * failure: only a human on this device can release it. */
+        if (status.has_prompt) {
+            size_t used = strlen(out);
+
+            snprintf(out + used, out_size - used,
+                "%s[The remote agent is waiting for approval of %s on this "
+                "device. It cannot continue until someone answers.]",
+                used > 0 ? "\n" : "", status.prompt.tool);
+        } else {
+            size_t used = strlen(out);
+
+            snprintf(out + used, out_size - used,
+                "%s[The remote turn is still running; output so far is above.]",
+                used > 0 ? "\n" : "");
+        }
+        ret = OK;
+    }
+
+    if (out[0] == '\0') {
+        snprintf(out, out_size, "The remote agent produced no text output.");
+    }
+
+    return ret;
+}
+
+#endif /* CONFIG_AI_AGENT_REMOTE_CTRL */

--- a/src/channels/remote_ctrl_channel.h
+++ b/src/channels/remote_ctrl_channel.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Remote-control channel: lets this device drive a remote ACP agent
+ * (mimocode / kiro-cli) that runs on a PC.
+ *
+ * Unlike the other channels, which bring a user's messages *into* the local
+ * agent, this one reaches *out*: the device is a client of a remote agent. A
+ * PC-side bridge speaks ACP to the agent and the frozen link contract to us, so
+ * the device never sees ACP session IDs, raw tool arguments, or credentials.
+ *
+ * Permission decisions are deliberately not part of the tool surface. See
+ * remote_ctrl_channel_decide().
+ */
+
+#pragma once
+
+#include "agent_compat.h"
+#include "remote/remote_link.h"
+#include "remote/remote_session.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+
+/* ── Lifecycle ─────────────────────────────────────────────────────── */
+
+/* Reads configuration and prepares the session. Returns OK even when no broker
+ * is configured; the channel then stays idle. */
+int remote_ctrl_channel_init(void);
+
+/* Starts the transport thread. No-op when unconfigured. */
+int remote_ctrl_channel_start(void);
+
+void remote_ctrl_channel_stop(void);
+
+/* True once a broker is configured, whether or not the link is up. */
+bool remote_ctrl_channel_enabled(void);
+
+/* ── Operations ────────────────────────────────────────────────────── */
+
+/* Consistent snapshot for display. Returns ERROR when unconfigured. */
+int remote_ctrl_channel_status(struct remote_status_s* out);
+
+/* Submits one prompt to the remote agent, then waits up to timeout_ms for the
+ * turn to finish, copying the agent's text into `out`.
+ *
+ * A turn that stalls on a remote permission request will not finish until a
+ * human answers on this device, so a timeout here is a normal outcome and is
+ * reported as such rather than treated as an error.
+ *
+ * Only for callers running on a thread a human is not typing on — see
+ * remote_ctrl_channel_submit(). */
+int remote_ctrl_channel_prompt(const char* text, uint32_t timeout_ms,
+    char* out, size_t out_size);
+
+/* Submits a prompt and returns immediately. Agent output arrives through the
+ * event handler and accumulates in the transcript. On failure `out` receives
+ * the reason.
+ *
+ * This is what the console uses. Blocking the console thread on a turn would
+ * put the permission commands out of reach, so a turn that stopped for approval
+ * could never be approved: the wait would deadlock on the input it waits for. */
+int remote_ctrl_channel_submit(const char* text, char* out, size_t out_size);
+
+/* Copies the bounded transcript of the remote agent's output so far. */
+int remote_ctrl_channel_transcript(char* out, size_t out_size);
+
+/* Read-only billing refresh. */
+int remote_ctrl_channel_query_usage(void);
+
+/* Copies the remote agent's model list for display. */
+int remote_ctrl_channel_model_view(struct remote_model_view_s* out);
+
+/* Requests a model for the rest of the remote session. Returns OK when the
+ * request was sent, which is not the same as applied: the bridge validates the
+ * name and reports the outcome in a `models` message. */
+int remote_ctrl_channel_select_model(const char* model);
+
+/* Answers a pending permission request from the remote agent.
+ *
+ * HUMAN INPUT ONLY. Reached from the NSH commands and, later, a GPIO key. This
+ * is intentionally absent from the tool registry: approving a remote agent's
+ * tool call is a human act, and a model that could both request and approve
+ * would make the whole permission model decorative. */
+int remote_ctrl_channel_decide(enum remote_decision_e decision);
+
+#else /* stubs */
+
+static inline int remote_ctrl_channel_init(void) { return OK; }
+static inline int remote_ctrl_channel_start(void) { return OK; }
+static inline void remote_ctrl_channel_stop(void) { }
+static inline bool remote_ctrl_channel_enabled(void) { return false; }
+
+#endif /* CONFIG_AI_AGENT_REMOTE_CTRL */
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/remote/remote_codec.c
+++ b/src/remote/remote_codec.c
@@ -1,0 +1,716 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "remote/remote_codec.h"
+#include "remote/remote_session.h"
+
+#include "cJSON.h"
+
+#include <float.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Staging buffer for one inbound message. The device runs a single remote
+ * session, and the transport delivers messages one at a time from its own
+ * thread, so a single buffer is sufficient and keeps this off the caller's
+ * stack. */
+static char g_inbound[REMOTE_MESSAGE_MAX + 1];
+
+/* ── Field helpers ─────────────────────────────────────────────────── */
+
+static bool valid_string(const cJSON* item)
+{
+    return cJSON_IsString(item) && item->valuestring != NULL;
+}
+
+static const cJSON* field(const cJSON* root, const char* name)
+{
+    return cJSON_GetObjectItemCaseSensitive(root, name);
+}
+
+/* cJSON decodes JSON \u0000 into a C string terminator. Reject its only legal
+ * wire representation before parsing so strcmp cannot turn an extended nonce
+ * or epoch into a prefix match. */
+static bool contains_escaped_nul(const char* payload, size_t length)
+{
+    size_t index;
+
+    for (index = 0; index < length; index++) {
+        if (payload[index] != '\\' || index + 1 >= length) {
+            continue;
+        }
+
+        if (payload[index + 1] == '\\') {
+            index++;
+            continue;
+        }
+
+        if (payload[index + 1] == 'u' && index + 5 < length) {
+            if (payload[index + 2] == '0' && payload[index + 3] == '0' && payload[index + 4] == '0' && payload[index + 5] == '0') {
+                return true;
+            }
+            index += 5;
+        } else {
+            index++;
+        }
+    }
+
+    return false;
+}
+
+static bool has_chat_turns_capability(const cJSON* capabilities)
+{
+    const cJSON* entry;
+
+    if (capabilities == NULL || !cJSON_IsArray(capabilities)) {
+        return false;
+    }
+
+    cJSON_ArrayForEach(entry, capabilities)
+    {
+        if (!valid_string(entry) || strlen(entry->valuestring) > 32) {
+            return false;
+        }
+        if (strcmp(entry->valuestring, "chat_turns") == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/* ── Scalar parsers ────────────────────────────────────────────────── */
+
+/* JSON numbers pass through cJSON as doubles. Stay inside JavaScript's
+ * exact-integer range: the Node bridge cannot faithfully emit larger integer
+ * token counts either. */
+static bool parse_uint64(const cJSON* value, uint64_t* out)
+{
+    const double maximum = 9007199254740991.0;
+    uint64_t converted;
+
+    if (!cJSON_IsNumber(value) || value->valuedouble != value->valuedouble || value->valuedouble < 0 || value->valuedouble > maximum) {
+        return false;
+    }
+
+    converted = (uint64_t)value->valuedouble;
+    if (value->valuedouble != (double)converted) {
+        return false;
+    }
+
+    *out = converted;
+    return true;
+}
+
+static bool parse_uint32(const cJSON* value, uint32_t* out)
+{
+    const double maximum = 4294967295.0;
+    uint32_t converted;
+
+    if (!cJSON_IsNumber(value) || value->valuedouble != value->valuedouble || value->valuedouble < 0 || value->valuedouble > maximum) {
+        return false;
+    }
+
+    converted = (uint32_t)value->valuedouble;
+    if (value->valuedouble != (double)converted) {
+        return false;
+    }
+
+    *out = converted;
+    return true;
+}
+
+static bool parse_nonnegative_number(const cJSON* value, double* out)
+{
+    if (!cJSON_IsNumber(value) || value->valuedouble < 0 || value->valuedouble != value->valuedouble || value->valuedouble > DBL_MAX) {
+        return false;
+    }
+
+    *out = value->valuedouble;
+    return true;
+}
+
+static bool valid_currency(const char* value)
+{
+    return value != NULL && strlen(value) == 3 && value[0] >= 'A' && value[0] <= 'Z' && value[1] >= 'A' && value[1] <= 'Z' && value[2] >= 'A' && value[2] <= 'Z';
+}
+
+/* ── Composite parsers ─────────────────────────────────────────────── */
+
+static bool parse_prompt(const cJSON* value, struct remote_prompt_s* prompt)
+{
+    const cJSON* id;
+    const cJSON* tool;
+    const cJSON* hint;
+    const cJSON* can_once;
+    const cJSON* can_deny;
+
+    if (cJSON_IsNull(value)) {
+        return true;
+    }
+
+    if (!cJSON_IsObject(value)) {
+        return false;
+    }
+
+    id = field(value, "id");
+    tool = field(value, "tool");
+    hint = field(value, "hint");
+    can_once = field(value, "canOnce");
+    can_deny = field(value, "canDeny");
+    if (!valid_string(id) || !valid_string(tool) || !valid_string(hint) || !cJSON_IsBool(can_once) || !cJSON_IsBool(can_deny) || strlen(id->valuestring) > REMOTE_PROMPT_ID_MAX || strlen(tool->valuestring) > REMOTE_TOOL_MAX || strlen(hint->valuestring) > REMOTE_HINT_MAX) {
+        return false;
+    }
+
+    memset(prompt, 0, sizeof(*prompt));
+    strcpy(prompt->id, id->valuestring);
+    strcpy(prompt->tool, tool->valuestring);
+    strcpy(prompt->hint, hint->valuestring);
+    prompt->can_once = cJSON_IsTrue(can_once);
+    prompt->can_deny = cJSON_IsTrue(can_deny);
+    return true;
+}
+
+static bool parse_charge(const cJSON* value,
+    struct remote_usage_snapshot_s* snapshot)
+{
+    const cJSON* kind;
+    const cJSON* amount;
+    const cJSON* unit;
+
+    if (cJSON_IsNull(value)) {
+        snapshot->has_charge = false;
+        return true;
+    }
+
+    if (!cJSON_IsObject(value)) {
+        return false;
+    }
+
+    kind = field(value, "kind");
+    amount = field(value, "amount");
+    if (!valid_string(kind) || !parse_nonnegative_number(amount, &snapshot->charge_amount)) {
+        return false;
+    }
+
+    if (strcmp(kind->valuestring, "credit") == 0) {
+        snapshot->charge_kind = REMOTE_CHARGE_CREDIT;
+        unit = field(value, "unit");
+    } else if (strcmp(kind->valuestring, "currency") == 0) {
+        snapshot->charge_kind = REMOTE_CHARGE_CURRENCY;
+        unit = field(value, "currency");
+    } else {
+        return false;
+    }
+
+    if (!valid_string(unit) || unit->valuestring[0] == '\0' || strlen(unit->valuestring) > REMOTE_BILLING_UNIT_MAX || (snapshot->charge_kind == REMOTE_CHARGE_CREDIT && strcmp(unit->valuestring, "credits") != 0) || (snapshot->charge_kind == REMOTE_CHARGE_CURRENCY && !valid_currency(unit->valuestring))) {
+        return false;
+    }
+
+    snapshot->has_charge = true;
+    snapshot->charge_unit = unit->valuestring;
+    return true;
+}
+
+static bool parse_tokens(const cJSON* value,
+    struct remote_usage_snapshot_s* snapshot)
+{
+    if (cJSON_IsNull(value)) {
+        snapshot->has_tokens = false;
+        return true;
+    }
+
+    if (!cJSON_IsObject(value)) {
+        return false;
+    }
+
+    if (!parse_uint64(field(value, "input"), &snapshot->input_tokens) || !parse_uint64(field(value, "output"), &snapshot->output_tokens) || !parse_uint64(field(value, "total"), &snapshot->total_tokens)) {
+        return false;
+    }
+
+    snapshot->has_tokens = true;
+    return true;
+}
+
+static bool parse_context(const cJSON* value,
+    struct remote_usage_snapshot_s* snapshot)
+{
+    const cJSON* unit;
+
+    if (cJSON_IsNull(value)) {
+        snapshot->has_context = false;
+        return true;
+    }
+
+    if (!cJSON_IsObject(value)) {
+        return false;
+    }
+
+    unit = field(value, "unit");
+    if (!valid_string(unit) || !parse_nonnegative_number(field(value, "used"), &snapshot->context_used) || !parse_nonnegative_number(field(value, "limit"), &snapshot->context_limit) || snapshot->context_limit <= 0) {
+        return false;
+    }
+
+    if (strcmp(unit->valuestring, "token") == 0) {
+        snapshot->context_unit = REMOTE_CONTEXT_TOKEN;
+    } else if (strcmp(unit->valuestring, "percent") == 0) {
+        snapshot->context_unit = REMOTE_CONTEXT_PERCENT;
+    } else {
+        return false;
+    }
+
+    snapshot->has_context = true;
+    return true;
+}
+
+/* ── Message handlers ──────────────────────────────────────────────── */
+
+static void receive_snapshot(struct remote_session_s* session,
+    const cJSON* root, uint32_t now_ms)
+{
+    const cJSON* nonce = field(root, "connection_nonce");
+    const cJSON* epoch = field(root, "epoch");
+    const cJSON* seq = field(root, "seq");
+    const cJSON* running = field(root, "running");
+    const cJSON* message = field(root, "msg");
+    const cJSON* prompt = field(root, "prompt");
+    struct remote_snapshot_s snapshot;
+    struct remote_prompt_s prompt_value;
+    uint32_t sequence;
+    uint32_t running_value;
+    bool display_changed;
+
+    if (!valid_string(nonce) || !valid_string(epoch) || strlen(nonce->valuestring) > REMOTE_NONCE_MAX || strlen(epoch->valuestring) > REMOTE_EPOCH_MAX || !parse_uint32(seq, &sequence) || sequence == 0 || !parse_uint32(running, &running_value) || running_value > UINT8_MAX || !valid_string(message) || strlen(message->valuestring) > REMOTE_SUMMARY_MAX || prompt == NULL || !parse_prompt(prompt, &prompt_value)) {
+        return;
+    }
+
+    snapshot.connection_nonce = nonce->valuestring;
+    snapshot.epoch = epoch->valuestring;
+    snapshot.seq = sequence;
+    snapshot.running = (uint8_t)running_value;
+    snapshot.summary = message->valuestring;
+    snapshot.prompt = cJSON_IsNull(prompt) ? NULL : &prompt_value;
+    remote_session_snapshot(session, &snapshot, now_ms, &display_changed);
+}
+
+static void receive_usage_snapshot(struct remote_session_s* session,
+    const cJSON* root)
+{
+    const cJSON* nonce = field(root, "connection_nonce");
+    const cJSON* epoch = field(root, "epoch");
+    const cJSON* sequence = field(root, "usage_seq");
+    const cJSON* usage = field(root, "usage");
+    const cJSON* scope;
+    const cJSON* billing;
+    const cJSON* charge;
+    const cJSON* tokens;
+    const cJSON* context;
+    struct remote_usage_snapshot_s snapshot = { 0 };
+    uint64_t sequence_value;
+    bool display_changed;
+
+    if (!valid_string(nonce) || !valid_string(epoch) || !parse_uint64(sequence, &sequence_value) || sequence_value == 0 || !cJSON_IsObject(usage)) {
+        return;
+    }
+
+    scope = field(usage, "scope");
+    billing = field(usage, "billing");
+    context = field(usage, "context");
+
+    /* Only bridge-session-local telemetry is accepted. This is never an
+     * account balance or a remaining quota. */
+    if (!valid_string(scope) || strcmp(scope->valuestring, "bridge_session") != 0 || !cJSON_IsObject(billing) || context == NULL) {
+        return;
+    }
+
+    charge = field(billing, "charge");
+    tokens = field(billing, "tokens");
+    if (charge == NULL || tokens == NULL || !parse_charge(charge, &snapshot) || !parse_tokens(tokens, &snapshot) || !parse_context(context, &snapshot)) {
+        return;
+    }
+
+    snapshot.connection_nonce = nonce->valuestring;
+    snapshot.epoch = epoch->valuestring;
+    snapshot.seq = sequence_value;
+    remote_session_usage_snapshot(session, &snapshot, &display_changed);
+}
+
+static void receive_tool_result(struct remote_session_s* session,
+    const cJSON* root)
+{
+    const cJSON* nonce = field(root, "connection_nonce");
+    const cJSON* epoch = field(root, "epoch");
+    const cJSON* tool_call_id = field(root, "toolCallId");
+    const cJSON* status = field(root, "status");
+    const cJSON* title = field(root, "title");
+    const char* title_text = NULL;
+
+    if (!valid_string(nonce) || !valid_string(epoch) || !valid_string(tool_call_id) || !valid_string(status) || strlen(nonce->valuestring) > REMOTE_NONCE_MAX || strlen(epoch->valuestring) > REMOTE_EPOCH_MAX || strlen(tool_call_id->valuestring) > REMOTE_PROMPT_ID_MAX) {
+        return;
+    }
+
+    /* The title is optional and cosmetic, so a malformed one is dropped rather
+     * than rejecting the whole result: the link then falls back to the tool-call
+     * id and the state machine still advances. An older bridge sends no title
+     * at all. */
+    if (title != NULL && valid_string(title) && strlen(title->valuestring) <= REMOTE_SUMMARY_MAX && remote_valid_utf8(title->valuestring)) {
+        title_text = title->valuestring;
+    }
+
+    /* The session checks the nonce/epoch binding under its own lock. */
+    remote_session_tool_result(session, nonce->valuestring, epoch->valuestring,
+        tool_call_id->valuestring, status->valuestring, title_text);
+}
+
+static void receive_models(struct remote_session_s* session, const cJSON* root)
+{
+    const cJSON* nonce = field(root, "connection_nonce");
+    const cJSON* epoch = field(root, "epoch");
+    const cJSON* current = field(root, "current");
+    const cJSON* options = field(root, "options");
+    const cJSON* truncated = field(root, "truncated");
+    const cJSON* entry;
+    /* Pointers into the parsed cJSON tree, valid until the caller deletes it.
+     * remote_link_models copies what it keeps, so nothing outlives this call. */
+    const char* names[REMOTE_MODEL_OPTIONS_MAX];
+    struct remote_models_s models;
+    size_t count = 0;
+    bool overflow = false;
+
+    if (!valid_string(nonce) || !valid_string(epoch) || !valid_string(current) || strlen(nonce->valuestring) > REMOTE_NONCE_MAX || strlen(epoch->valuestring) > REMOTE_EPOCH_MAX || (options != NULL && !cJSON_IsArray(options)) || (truncated != NULL && !cJSON_IsBool(truncated))) {
+        return;
+    }
+
+    if (options != NULL) {
+        cJSON_ArrayForEach(entry, options)
+        {
+            if (count >= REMOTE_MODEL_OPTIONS_MAX) {
+                /* More on offer than the device holds. Recorded so the console
+                 * can say the list is partial instead of implying it is all. */
+                overflow = true;
+                break;
+            }
+
+            if (!valid_string(entry)) {
+                overflow = true;
+                continue;
+            }
+
+            names[count] = entry->valuestring;
+            count++;
+        }
+    }
+
+    models.connection_nonce = nonce->valuestring;
+    models.epoch = epoch->valuestring;
+    models.current = current->valuestring;
+    models.options = names;
+    models.count = count;
+    models.truncated = overflow || cJSON_IsTrue(truncated);
+    remote_session_models(session, &models);
+}
+
+static void receive_hello_ack(struct remote_session_s* session,
+    const cJSON* root)
+{
+    const cJSON* nonce = field(root, "connection_nonce");
+    const cJSON* epoch = field(root, "epoch");
+    const cJSON* capabilities = field(root, "capabilities");
+    struct remote_hello_ack_s ack;
+
+    if (!valid_string(nonce) || !valid_string(epoch) || strlen(nonce->valuestring) > REMOTE_NONCE_MAX || strlen(epoch->valuestring) > REMOTE_EPOCH_MAX || (capabilities != NULL && !cJSON_IsArray(capabilities))) {
+        return;
+    }
+
+    ack.connection_nonce = nonce->valuestring;
+    ack.epoch = epoch->valuestring;
+    ack.chat_turns = has_chat_turns_capability(capabilities);
+    remote_session_hello_ack(session, &ack);
+}
+
+static void receive_prompt_ack(struct remote_session_s* session,
+    const cJSON* root)
+{
+    const cJSON* nonce = field(root, "connection_nonce");
+    const cJSON* epoch = field(root, "epoch");
+    const cJSON* request_id = field(root, "request_id");
+    const cJSON* turn_id = field(root, "turn_id");
+    const cJSON* accepted = field(root, "accepted");
+    const cJSON* error = field(root, "error");
+    struct remote_prompt_ack_s ack;
+
+    if (!valid_string(nonce) || !valid_string(epoch) || !valid_string(request_id) || !cJSON_IsBool(accepted) || strlen(request_id->valuestring) > REMOTE_REQUEST_ID_MAX || strlen(nonce->valuestring) > REMOTE_NONCE_MAX || strlen(epoch->valuestring) > REMOTE_EPOCH_MAX || (cJSON_IsTrue(accepted) && (!valid_string(turn_id) || strlen(turn_id->valuestring) > REMOTE_TURN_ID_MAX)) || (!cJSON_IsTrue(accepted) && error != NULL && (!valid_string(error) || strlen(error->valuestring) > 32))) {
+        return;
+    }
+
+    ack.connection_nonce = nonce->valuestring;
+    ack.epoch = epoch->valuestring;
+    ack.request_id = request_id->valuestring;
+    ack.turn_id = cJSON_IsTrue(accepted) ? turn_id->valuestring : NULL;
+    ack.accepted = cJSON_IsTrue(accepted);
+    remote_session_prompt_ack(session, &ack);
+}
+
+static void receive_agent_output(struct remote_session_s* session,
+    const cJSON* root)
+{
+    const cJSON* nonce = field(root, "connection_nonce");
+    const cJSON* epoch = field(root, "epoch");
+    const cJSON* request_id = field(root, "request_id");
+    const cJSON* turn_id = field(root, "turn_id");
+    const cJSON* seq = field(root, "output_seq");
+    const cJSON* text = field(root, "text");
+    struct remote_agent_output_s output;
+    uint32_t sequence;
+    size_t text_length;
+    bool gap;
+
+    if (!valid_string(nonce) || !valid_string(epoch) || !valid_string(request_id) || !valid_string(turn_id) || !valid_string(text) || !parse_uint32(seq, &sequence) || sequence == 0 || strlen(request_id->valuestring) > REMOTE_REQUEST_ID_MAX || strlen(nonce->valuestring) > REMOTE_NONCE_MAX || strlen(epoch->valuestring) > REMOTE_EPOCH_MAX || strlen(turn_id->valuestring) > REMOTE_TURN_ID_MAX) {
+        return;
+    }
+
+    text_length = strlen(text->valuestring);
+    if (text_length == 0 || text_length > REMOTE_OUTPUT_TEXT_MAX) {
+        return;
+    }
+
+    output.connection_nonce = nonce->valuestring;
+    output.epoch = epoch->valuestring;
+    output.request_id = request_id->valuestring;
+    output.turn_id = turn_id->valuestring;
+    output.seq = sequence;
+    output.text = text->valuestring;
+    remote_session_agent_output(session, &output, &gap);
+}
+
+static void receive_turn_result(struct remote_session_s* session,
+    const cJSON* root)
+{
+    const cJSON* nonce = field(root, "connection_nonce");
+    const cJSON* epoch = field(root, "epoch");
+    const cJSON* request_id = field(root, "request_id");
+    const cJSON* turn_id = field(root, "turn_id");
+    const cJSON* status = field(root, "status");
+    struct remote_turn_result_s result;
+
+    if (!valid_string(nonce) || !valid_string(epoch) || !valid_string(request_id) || !valid_string(turn_id) || !valid_string(status) || strlen(request_id->valuestring) > REMOTE_REQUEST_ID_MAX || strlen(nonce->valuestring) > REMOTE_NONCE_MAX || strlen(epoch->valuestring) > REMOTE_EPOCH_MAX || strlen(turn_id->valuestring) > REMOTE_TURN_ID_MAX) {
+        return;
+    }
+
+    result.connection_nonce = nonce->valuestring;
+    result.epoch = epoch->valuestring;
+    result.request_id = request_id->valuestring;
+    result.turn_id = turn_id->valuestring;
+    result.status = status->valuestring;
+    remote_session_turn_result(session, &result);
+}
+
+/* ── Inbound entry point ───────────────────────────────────────────── */
+
+void remote_codec_receive(struct remote_session_s* session,
+    const char* payload, size_t length, uint32_t now_ms)
+{
+    cJSON* root;
+    const char* end = NULL;
+    const cJSON* version;
+    const cJSON* type;
+
+    /* Oversized messages are dropped whole rather than parsed partially: the
+     * link contract caps every message, so anything larger is not ours. */
+    if (session == NULL || payload == NULL || length == 0 || length > REMOTE_MESSAGE_MAX) {
+        return;
+    }
+
+    if (contains_escaped_nul(payload, length)) {
+        return;
+    }
+
+    memcpy(g_inbound, payload, length);
+    g_inbound[length] = '\0';
+
+    /* Require the parse to consume exactly the payload: trailing bytes after a
+     * valid object would otherwise pass unnoticed. */
+    root = cJSON_ParseWithLengthOpts(g_inbound, length + 1, &end, 1);
+    if (root == NULL || end != g_inbound + length || !cJSON_IsObject(root)) {
+        cJSON_Delete(root);
+        return;
+    }
+
+    version = field(root, "v");
+    type = field(root, "type");
+    if (!cJSON_IsNumber(version) || version->valuedouble != 1 || !valid_string(type)) {
+        cJSON_Delete(root);
+        return;
+    }
+
+    if (strcmp(type->valuestring, "hello_ack") == 0) {
+        receive_hello_ack(session, root);
+    } else if (strcmp(type->valuestring, "snapshot") == 0) {
+        receive_snapshot(session, root, now_ms);
+    } else if (strcmp(type->valuestring, "usage_snapshot") == 0) {
+        receive_usage_snapshot(session, root);
+    } else if (strcmp(type->valuestring, "tool_result") == 0) {
+        receive_tool_result(session, root);
+    } else if (strcmp(type->valuestring, "prompt_ack") == 0) {
+        receive_prompt_ack(session, root);
+    } else if (strcmp(type->valuestring, "agent_output") == 0) {
+        receive_agent_output(session, root);
+    } else if (strcmp(type->valuestring, "turn_result") == 0) {
+        receive_turn_result(session, root);
+    } else if (strcmp(type->valuestring, "models") == 0) {
+        receive_models(session, root);
+    }
+
+    cJSON_Delete(root);
+}
+
+/* ── Outbound builders ─────────────────────────────────────────────── */
+
+/* Serializes and copies out, enforcing the link's message cap. cJSON owns the
+ * escaping, so no command may inject raw text into the wire form. */
+static bool finish(cJSON* root, char* out, size_t out_size)
+{
+    char* json;
+    size_t length;
+    bool ok = false;
+
+    if (root == NULL) {
+        return false;
+    }
+
+    json = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (json == NULL) {
+        return false;
+    }
+
+    length = strlen(json);
+    if (length <= REMOTE_MESSAGE_MAX && length < out_size) {
+        memcpy(out, json, length + 1);
+        ok = true;
+    }
+
+    free(json);
+    return ok;
+}
+
+static cJSON* begin_command(const char* command)
+{
+    cJSON* root = cJSON_CreateObject();
+
+    if (root == NULL) {
+        return NULL;
+    }
+
+    if (cJSON_AddNumberToObject(root, "v", 1) == NULL || cJSON_AddStringToObject(root, "cmd", command) == NULL) {
+        cJSON_Delete(root);
+        return NULL;
+    }
+
+    return root;
+}
+
+bool remote_codec_build_hello(const struct remote_link_s* link, char* out,
+    size_t out_size)
+{
+    cJSON* root;
+
+    if (link == NULL || out == NULL || out_size == 0 || !remote_valid_identifier(link->nonce, REMOTE_NONCE_MAX)) {
+        return false;
+    }
+
+    root = begin_command("hello");
+    if (root == NULL || cJSON_AddStringToObject(root, "connection_nonce", link->nonce) == NULL) {
+        cJSON_Delete(root);
+        return false;
+    }
+
+    return finish(root, out, out_size);
+}
+
+bool remote_codec_build_decision(const struct remote_link_s* link,
+    enum remote_decision_e decision, char* out, size_t out_size)
+{
+    const char* value = remote_link_decision_value(link, decision);
+    cJSON* root;
+
+    if (value == NULL || out == NULL || out_size == 0) {
+        return false;
+    }
+
+    root = begin_command("permission");
+    if (root == NULL || cJSON_AddStringToObject(root, "connection_nonce", link->nonce) == NULL || cJSON_AddStringToObject(root, "epoch", link->epoch) == NULL || cJSON_AddStringToObject(root, "id", link->prompt.id) == NULL || cJSON_AddStringToObject(root, "decision", value) == NULL) {
+        cJSON_Delete(root);
+        return false;
+    }
+
+    return finish(root, out, out_size);
+}
+
+bool remote_codec_build_usage_query(const struct remote_link_s* link,
+    char* out, size_t out_size)
+{
+    cJSON* root;
+
+    if (!remote_link_can_query_usage(link) || out == NULL || out_size == 0) {
+        return false;
+    }
+
+    root = begin_command("usage_query");
+    if (root == NULL || cJSON_AddStringToObject(root, "connection_nonce", link->nonce) == NULL || cJSON_AddStringToObject(root, "epoch", link->epoch) == NULL) {
+        cJSON_Delete(root);
+        return false;
+    }
+
+    return finish(root, out, out_size);
+}
+
+bool remote_codec_build_prompt_submit(const struct remote_link_s* link,
+    const char* request_id, const char* text, char* out, size_t out_size)
+{
+    cJSON* root;
+
+    if (!remote_link_can_submit_prompt(link, text) || out == NULL || out_size == 0 || !remote_valid_identifier(request_id, REMOTE_REQUEST_ID_MAX)) {
+        return false;
+    }
+
+    root = begin_command("prompt_submit");
+    if (root == NULL || cJSON_AddStringToObject(root, "connection_nonce", link->nonce) == NULL || cJSON_AddStringToObject(root, "epoch", link->epoch) == NULL || cJSON_AddStringToObject(root, "request_id", request_id) == NULL || cJSON_AddStringToObject(root, "text", text) == NULL) {
+        cJSON_Delete(root);
+        return false;
+    }
+
+    return finish(root, out, out_size);
+}
+
+bool remote_codec_build_model_select(const struct remote_link_s* link,
+    const char* model, char* out, size_t out_size)
+{
+    cJSON* root;
+
+    if (!remote_link_can_select_model(link, model) || out == NULL || out_size == 0) {
+        return false;
+    }
+
+    root = begin_command("model_select");
+    if (root == NULL || cJSON_AddStringToObject(root, "connection_nonce", link->nonce) == NULL || cJSON_AddStringToObject(root, "epoch", link->epoch) == NULL || cJSON_AddStringToObject(root, "model", model) == NULL) {
+        cJSON_Delete(root);
+        return false;
+    }
+
+    return finish(root, out, out_size);
+}

--- a/src/remote/remote_codec.h
+++ b/src/remote/remote_codec.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Wire codec: the only layer that knows the link is carried as JSON.
+ *
+ * Inbound messages are validated here and handed to the session as decoded
+ * structures; the session and the state machine never see JSON. Keeping this
+ * layer separate is what makes a future direct-ACP backend an added codec
+ * rather than a rewrite of the state machine.
+ */
+
+#pragma once
+
+#include "remote/remote_link.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* The encoded message cap lives with the protocol constants in remote_link.h
+ * (REMOTE_MESSAGE_MAX) so the state machine, the session's staging buffer and
+ * this codec cannot drift apart. */
+
+/* Buffer sizes callers should use for the builders below. */
+#define REMOTE_CODEC_HELLO_BUF 128
+#define REMOTE_CODEC_DECISION_BUF 512
+#define REMOTE_CODEC_USAGE_QUERY_BUF 192
+#define REMOTE_CODEC_MODEL_SELECT_BUF 320
+
+struct remote_session_s;
+
+/* ── Inbound ───────────────────────────────────────────────────────── */
+
+/* Validates one complete wire message and applies it to the session. Silently
+ * ignores anything malformed, oversized, stale, or out of session. `now_ms` is
+ * only used to refresh authority-snapshot liveness. */
+void remote_codec_receive(struct remote_session_s* session,
+    const char* payload, size_t length, uint32_t now_ms);
+
+/* ── Outbound ──────────────────────────────────────────────────────── */
+
+bool remote_codec_build_hello(const struct remote_link_s* link, char* out,
+    size_t out_size);
+bool remote_codec_build_decision(const struct remote_link_s* link,
+    enum remote_decision_e decision, char* out, size_t out_size);
+bool remote_codec_build_usage_query(const struct remote_link_s* link,
+    char* out, size_t out_size);
+bool remote_codec_build_prompt_submit(const struct remote_link_s* link,
+    const char* request_id, const char* text, char* out, size_t out_size);
+bool remote_codec_build_model_select(const struct remote_link_s* link,
+    const char* model, char* out, size_t out_size);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/remote/remote_link.c
+++ b/src/remote/remote_link.c
@@ -1,0 +1,653 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "remote/remote_link.h"
+
+#include <float.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+/* ── Local helpers ─────────────────────────────────────────────────── */
+
+static void copy_bounded(char* out, size_t out_size, const char* value)
+{
+    if (out_size == 0) {
+        return;
+    }
+
+    if (value == NULL) {
+        out[0] = '\0';
+        return;
+    }
+
+    strncpy(out, value, out_size - 1);
+    out[out_size - 1] = '\0';
+}
+
+/* A summary is rendered as a single status line, so a control character inside
+ * it — a newline in a tool title being the common case — would split that line
+ * in two and make a status line read like a truncated transcript. Only ASCII
+ * control bytes are replaced; anything >= 0x80 is left alone so multi-byte UTF-8
+ * survives intact. */
+static void flatten_summary(char* text)
+{
+    size_t i;
+
+    if (text == NULL) {
+        return;
+    }
+
+    for (i = 0; text[i] != '\0'; i++) {
+        unsigned char byte = (unsigned char)text[i];
+
+        if (byte < 0x20 || byte == 0x7f) {
+            text[i] = ' ';
+        }
+    }
+}
+
+static void clear_prompt(struct remote_link_s* link)
+{
+    memset(&link->prompt, 0, sizeof(link->prompt));
+    link->has_prompt = false;
+}
+
+/* Offline means the model in use is unknown, not "still the last one seen": the
+ * bridge may be restarted against a different session before we hear again. */
+static void clear_models(struct remote_link_s* link)
+{
+    link->model[0] = '\0';
+    link->model_count = 0;
+    link->models_truncated = false;
+}
+
+static void clear_usage(struct remote_link_s* link)
+{
+    memset(&link->usage, 0, sizeof(link->usage));
+}
+
+static void clear_turn(struct remote_link_s* link, bool clear_transcript)
+{
+    link->turn_active = false;
+    link->turn_request_id[0] = '\0';
+    link->turn_id[0] = '\0';
+    link->last_output_seq = 0;
+    link->output_gap = false;
+    if (clear_transcript) {
+        link->transcript[0] = '\0';
+    }
+}
+
+bool remote_valid_utf8(const char* text)
+{
+    const unsigned char* cursor = (const unsigned char*)text;
+
+    if (text == NULL) {
+        return false;
+    }
+
+    while (*cursor != '\0') {
+        if (*cursor < 0x80) {
+            cursor++;
+        } else if (*cursor >= 0xc2 && *cursor <= 0xdf && cursor[1] != '\0' && (cursor[1] & 0xc0) == 0x80) {
+            cursor += 2;
+        } else if (*cursor >= 0xe0 && *cursor <= 0xef && cursor[1] != '\0' && cursor[2] != '\0' && (cursor[1] & 0xc0) == 0x80 && (cursor[2] & 0xc0) == 0x80 && !(*cursor == 0xe0 && cursor[1] < 0xa0) && !(*cursor == 0xed && cursor[1] >= 0xa0)) {
+            cursor += 3;
+        } else if (*cursor >= 0xf0 && *cursor <= 0xf4 && cursor[1] != '\0' && cursor[2] != '\0' && cursor[3] != '\0' && (cursor[1] & 0xc0) == 0x80 && (cursor[2] & 0xc0) == 0x80 && (cursor[3] & 0xc0) == 0x80 && !(*cursor == 0xf0 && cursor[1] < 0x90) && !(*cursor == 0xf4 && cursor[1] >= 0x90)) {
+            cursor += 4;
+        } else {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool remote_valid_identifier(const char* value, size_t maximum)
+{
+    const unsigned char* cursor = (const unsigned char*)value;
+
+    if (value == NULL || value[0] == '\0' || strlen(value) > maximum || !remote_valid_utf8(value)) {
+        return false;
+    }
+
+    while (*cursor != '\0') {
+        if (*cursor < 0x20 || *cursor == 0x7f) {
+            return false;
+        }
+        cursor++;
+    }
+
+    return true;
+}
+
+/* Agent text may contain newlines but no other control characters. */
+static bool valid_agent_text(const char* value)
+{
+    const unsigned char* cursor = (const unsigned char*)value;
+
+    if (value == NULL || value[0] == '\0' || strlen(value) > REMOTE_OUTPUT_TEXT_MAX || !remote_valid_utf8(value)) {
+        return false;
+    }
+
+    while (*cursor != '\0') {
+        if (*cursor < 0x20 && *cursor != '\n') {
+            return false;
+        }
+        cursor++;
+    }
+
+    return true;
+}
+
+static bool has_nonspace(const char* value)
+{
+    while (value != NULL && *value != '\0') {
+        if (*value != ' ' && *value != '\t' && *value != '\n' && *value != '\r') {
+            return true;
+        }
+        value++;
+    }
+    return false;
+}
+
+/* Keeps a bounded tail of agent output. Drops whole UTF-8 sequences so the
+ * retained transcript never starts mid-character. */
+static void append_transcript(struct remote_link_s* link, const char* text)
+{
+    size_t existing = strlen(link->transcript);
+    size_t added = strlen(text);
+    size_t drop = existing + added > REMOTE_TRANSCRIPT_MAX
+        ? existing + added - REMOTE_TRANSCRIPT_MAX
+        : 0;
+
+    if (drop >= existing) {
+        size_t start = added - (REMOTE_TRANSCRIPT_MAX < added ? REMOTE_TRANSCRIPT_MAX : added);
+
+        while (text[start] != '\0' && ((unsigned char)text[start] & 0xc0) == 0x80) {
+            start++;
+        }
+        copy_bounded(link->transcript, sizeof(link->transcript), text + start);
+        return;
+    }
+
+    if (drop > 0) {
+        while (drop < existing && ((unsigned char)link->transcript[drop] & 0xc0) == 0x80) {
+            drop++;
+        }
+        memmove(link->transcript, link->transcript + drop, existing - drop + 1);
+    }
+
+    strncat(link->transcript, text, sizeof(link->transcript) - strlen(link->transcript) - 1);
+}
+
+static bool same_prompt(const struct remote_prompt_s* left,
+    const struct remote_prompt_s* right)
+{
+    return strcmp(left->id, right->id) == 0 && strcmp(left->tool, right->tool) == 0 && strcmp(left->hint, right->hint) == 0 && left->can_once == right->can_once && left->can_deny == right->can_deny;
+}
+
+static bool valid_nonnegative_double(double value)
+{
+    return value == value && value >= 0 && value <= DBL_MAX;
+}
+
+static bool same_usage(const struct remote_usage_s* left,
+    const struct remote_usage_snapshot_s* right)
+{
+    return left->has_charge == right->has_charge && (!left->has_charge || (left->charge_kind == right->charge_kind && left->charge_amount == right->charge_amount && strcmp(left->charge_unit, right->charge_unit) == 0)) && left->has_tokens == right->has_tokens && (!left->has_tokens || (left->input_tokens == right->input_tokens && left->output_tokens == right->output_tokens && left->total_tokens == right->total_tokens)) && left->has_context == right->has_context && (!left->has_context || (left->context_unit == right->context_unit && left->context_used == right->context_used && left->context_limit == right->context_limit));
+}
+
+static bool valid_usage_snapshot(const struct remote_link_s* link,
+    const struct remote_usage_snapshot_s* snapshot)
+{
+    if (snapshot == NULL || snapshot->connection_nonce == NULL || snapshot->epoch == NULL || link->epoch[0] == '\0' || !remote_valid_identifier(snapshot->connection_nonce, REMOTE_NONCE_MAX) || !remote_valid_identifier(snapshot->epoch, REMOTE_EPOCH_MAX) || strcmp(snapshot->connection_nonce, link->nonce) != 0 || strcmp(snapshot->epoch, link->epoch) != 0 || snapshot->seq == 0 || snapshot->seq <= link->usage.last_seq) {
+        return false;
+    }
+
+    if (snapshot->has_charge && ((snapshot->charge_kind != REMOTE_CHARGE_CREDIT && snapshot->charge_kind != REMOTE_CHARGE_CURRENCY) || snapshot->charge_unit == NULL || strlen(snapshot->charge_unit) > REMOTE_BILLING_UNIT_MAX || !valid_nonnegative_double(snapshot->charge_amount))) {
+        return false;
+    }
+
+    return !snapshot->has_context || ((snapshot->context_unit == REMOTE_CONTEXT_TOKEN || snapshot->context_unit == REMOTE_CONTEXT_PERCENT) && valid_nonnegative_double(snapshot->context_used) && valid_nonnegative_double(snapshot->context_limit) && snapshot->context_limit > 0);
+}
+
+/* ── Lifecycle ─────────────────────────────────────────────────────── */
+
+void remote_link_init(struct remote_link_s* link, const char* nonce)
+{
+    memset(link, 0, sizeof(*link));
+    copy_bounded(link->nonce, sizeof(link->nonce), nonce);
+    link->state = REMOTE_STATE_OFFLINE;
+}
+
+void remote_link_down(struct remote_link_s* link)
+{
+    link->epoch[0] = '\0';
+    link->next_seq = 0;
+    link->last_snapshot_ms = 0;
+    link->summary[0] = '\0';
+    clear_prompt(link);
+    clear_usage(link);
+    clear_models(link);
+    link->chat_epoch[0] = '\0';
+    link->chat_supported = false;
+    clear_turn(link, true);
+    link->state = REMOTE_STATE_OFFLINE;
+}
+
+/* ── Inbound authority ─────────────────────────────────────────────── */
+
+bool remote_link_snapshot(struct remote_link_s* link,
+    const struct remote_snapshot_s* snapshot, uint32_t now_ms,
+    bool* display_changed)
+{
+    enum remote_state_e next_state;
+    bool next_has_prompt;
+    bool changed;
+    char next_summary[REMOTE_SUMMARY_MAX + 1];
+
+    if (display_changed != NULL) {
+        *display_changed = false;
+    }
+
+    if (snapshot == NULL || snapshot->connection_nonce == NULL || snapshot->epoch == NULL || snapshot->summary == NULL || strlen(snapshot->summary) > REMOTE_SUMMARY_MAX || !remote_valid_identifier(snapshot->connection_nonce, REMOTE_NONCE_MAX) || !remote_valid_identifier(snapshot->epoch, REMOTE_EPOCH_MAX) || (snapshot->prompt != NULL && !remote_valid_identifier(snapshot->prompt->id, REMOTE_PROMPT_ID_MAX)) || strcmp(snapshot->connection_nonce, link->nonce) != 0) {
+        return false;
+    }
+
+    /* First snapshot of a connection locks the epoch and the sequence base. */
+    if (link->epoch[0] == '\0') {
+        copy_bounded(link->epoch, sizeof(link->epoch), snapshot->epoch);
+        link->next_seq = 1;
+        link->usage.last_seq = 0;
+        if (strcmp(link->chat_epoch, link->epoch) != 0) {
+            link->chat_supported = false;
+        }
+    }
+
+    if (strcmp(snapshot->epoch, link->epoch) != 0 || snapshot->seq != link->next_seq) {
+        return false;
+    }
+
+    next_has_prompt = snapshot->prompt != NULL;
+    if (next_has_prompt) {
+        next_state = REMOTE_STATE_ATTENTION;
+    } else if (snapshot->running > 0) {
+        next_state = REMOTE_STATE_BUSY;
+    } else {
+        next_state = REMOTE_STATE_IDLE;
+    }
+
+    /* Flatten before comparing, never after storing: the stored summary is the
+     * flattened form, so comparing it against the raw incoming one would differ
+     * on every snapshot whose summary carries a control byte, report a change
+     * each time, and turn a quiet link into a stream of identical status lines. */
+    copy_bounded(next_summary, sizeof(next_summary), snapshot->summary);
+    flatten_summary(next_summary);
+
+    changed = link->state != next_state || strcmp(link->summary, next_summary) != 0 || link->has_prompt != next_has_prompt || (next_has_prompt && !same_prompt(&link->prompt, snapshot->prompt));
+
+    link->next_seq++;
+    link->last_snapshot_ms = now_ms;
+    copy_bounded(link->summary, sizeof(link->summary), next_summary);
+    if (!next_has_prompt) {
+        clear_prompt(link);
+    } else {
+        link->prompt = *snapshot->prompt;
+        link->prompt.id[REMOTE_PROMPT_ID_MAX] = '\0';
+        link->prompt.tool[REMOTE_TOOL_MAX] = '\0';
+        link->prompt.hint[REMOTE_HINT_MAX] = '\0';
+        link->has_prompt = true;
+    }
+    link->state = next_state;
+
+    if (display_changed != NULL) {
+        *display_changed = changed;
+    }
+
+    return true;
+}
+
+bool remote_link_timeout(struct remote_link_s* link, uint32_t now_ms)
+{
+    if (link->state == REMOTE_STATE_OFFLINE || now_ms - link->last_snapshot_ms <= REMOTE_SNAPSHOT_TIMEOUT_MS) {
+        return false;
+    }
+
+    remote_link_down(link);
+    return true;
+}
+
+bool remote_link_tool_result(struct remote_link_s* link,
+    const char* tool_call_id, const char* status, const char* title)
+{
+    const char* label;
+
+    if (link == NULL || tool_call_id == NULL || status == NULL || (strcmp(status, "completed") != 0 && strcmp(status, "failed") != 0)) {
+        return false;
+    }
+
+    /* A tool result is not authority to clear a still-pending permission. Tool
+     * calls that did not request device permission can complete at any time. */
+    if (link->has_prompt) {
+        return false;
+    }
+
+    /* Prefer the name a human can read. The id stays as the fallback so an older
+     * bridge that sends no title still produces a usable line. */
+    label = (title != NULL && title[0] != '\0') ? title : tool_call_id;
+    snprintf(link->summary, sizeof(link->summary), "tool '%s' %s", label, status);
+    flatten_summary(link->summary);
+    clear_prompt(link);
+    link->state = REMOTE_STATE_RESULT;
+    return true;
+}
+
+bool remote_link_usage_snapshot(struct remote_link_s* link,
+    const struct remote_usage_snapshot_s* snapshot, bool* display_changed)
+{
+    bool changed;
+
+    if (display_changed != NULL) {
+        *display_changed = false;
+    }
+
+    if (!valid_usage_snapshot(link, snapshot)) {
+        return false;
+    }
+
+    changed = !same_usage(&link->usage, snapshot);
+    link->usage.last_seq = snapshot->seq;
+    link->usage.has_charge = snapshot->has_charge;
+    link->usage.charge_kind = snapshot->charge_kind;
+    link->usage.charge_amount = snapshot->charge_amount;
+    copy_bounded(link->usage.charge_unit, sizeof(link->usage.charge_unit),
+        snapshot->has_charge ? snapshot->charge_unit : "");
+    link->usage.has_tokens = snapshot->has_tokens;
+    link->usage.input_tokens = snapshot->input_tokens;
+    link->usage.output_tokens = snapshot->output_tokens;
+    link->usage.total_tokens = snapshot->total_tokens;
+    link->usage.has_context = snapshot->has_context;
+    link->usage.context_unit = snapshot->context_unit;
+    link->usage.context_used = snapshot->context_used;
+    link->usage.context_limit = snapshot->context_limit;
+
+    if (display_changed != NULL) {
+        *display_changed = changed;
+    }
+
+    return true;
+}
+
+bool remote_link_models(struct remote_link_s* link,
+    const struct remote_models_s* models)
+{
+    size_t i;
+    uint8_t stored = 0;
+    bool dropped = false;
+
+    if (link == NULL || models == NULL || models->connection_nonce == NULL || models->epoch == NULL || link->epoch[0] == '\0' || !remote_valid_identifier(models->connection_nonce, REMOTE_NONCE_MAX) || !remote_valid_identifier(models->epoch, REMOTE_EPOCH_MAX) || strcmp(models->connection_nonce, link->nonce) != 0 || strcmp(models->epoch, link->epoch) != 0 || !remote_valid_identifier(models->current, REMOTE_MODEL_MAX)) {
+        return false;
+    }
+
+    /* An unusable entry is skipped rather than failing the message: the current
+     * model is the part that matters, and a partial list still lets most of the
+     * numbered choices work. Whatever was dropped is reported as truncation. */
+    for (i = 0; i < models->count && models->options != NULL; i++) {
+        const char* option = models->options[i];
+
+        if (!remote_valid_identifier(option, REMOTE_MODEL_MAX)) {
+            dropped = true;
+            continue;
+        }
+
+        if (stored >= REMOTE_MODEL_OPTIONS_MAX) {
+            dropped = true;
+            break;
+        }
+
+        copy_bounded(link->model_options[stored], REMOTE_MODEL_MAX + 1, option);
+        stored++;
+    }
+
+    copy_bounded(link->model, sizeof(link->model), models->current);
+    link->model_count = stored;
+    link->models_truncated = models->truncated || dropped;
+    return true;
+}
+
+/* ── Chat turns ────────────────────────────────────────────────────── */
+
+bool remote_link_hello_ack(struct remote_link_s* link,
+    const struct remote_hello_ack_s* ack)
+{
+    if (link == NULL || ack == NULL || ack->connection_nonce == NULL || ack->epoch == NULL || strcmp(ack->connection_nonce, link->nonce) != 0 || !remote_valid_identifier(ack->connection_nonce, REMOTE_NONCE_MAX) || !remote_valid_identifier(ack->epoch, REMOTE_EPOCH_MAX)) {
+        return false;
+    }
+
+    copy_bounded(link->chat_epoch, sizeof(link->chat_epoch), ack->epoch);
+    link->chat_supported = ack->chat_turns;
+    return true;
+}
+
+bool remote_link_turn_submitted(struct remote_link_s* link,
+    const char* request_id)
+{
+    if (link == NULL || link->turn_active || !remote_valid_identifier(request_id, REMOTE_REQUEST_ID_MAX)) {
+        return false;
+    }
+
+    clear_turn(link, true);
+    copy_bounded(link->turn_request_id, sizeof(link->turn_request_id), request_id);
+    link->turn_active = true;
+    return true;
+}
+
+bool remote_link_turn_abort(struct remote_link_s* link, const char* request_id)
+{
+    if (link == NULL || !link->turn_active || request_id == NULL || strcmp(link->turn_request_id, request_id) != 0) {
+        return false;
+    }
+
+    /* Keeps the transcript: a send that never left the device produced no
+     * agent output of its own. */
+    clear_turn(link, false);
+    return true;
+}
+
+bool remote_link_prompt_ack(struct remote_link_s* link,
+    const struct remote_prompt_ack_s* ack)
+{
+    if (link == NULL || ack == NULL || ack->connection_nonce == NULL || ack->epoch == NULL || !remote_valid_identifier(ack->request_id, REMOTE_REQUEST_ID_MAX) || !remote_valid_identifier(ack->connection_nonce, REMOTE_NONCE_MAX) || !remote_valid_identifier(ack->epoch, REMOTE_EPOCH_MAX) || strcmp(ack->connection_nonce, link->nonce) != 0 || strcmp(ack->epoch, link->epoch) != 0 || !link->turn_active || strcmp(ack->request_id, link->turn_request_id) != 0) {
+        return false;
+    }
+
+    if (!ack->accepted) {
+        clear_turn(link, false);
+        return true;
+    }
+
+    if (!remote_valid_identifier(ack->turn_id, REMOTE_TURN_ID_MAX)) {
+        return false;
+    }
+
+    if (link->turn_id[0] != '\0' && strcmp(link->turn_id, ack->turn_id) != 0) {
+        return false;
+    }
+
+    copy_bounded(link->turn_id, sizeof(link->turn_id), ack->turn_id);
+    return true;
+}
+
+bool remote_link_agent_output(struct remote_link_s* link,
+    const struct remote_agent_output_s* output, bool* gap_detected)
+{
+    bool gap;
+
+    if (gap_detected != NULL) {
+        *gap_detected = false;
+    }
+
+    if (link == NULL || output == NULL || output->connection_nonce == NULL || output->epoch == NULL || !remote_valid_identifier(output->request_id, REMOTE_REQUEST_ID_MAX) || !remote_valid_identifier(output->turn_id, REMOTE_TURN_ID_MAX) || !remote_valid_identifier(output->connection_nonce, REMOTE_NONCE_MAX) || !remote_valid_identifier(output->epoch, REMOTE_EPOCH_MAX) || !valid_agent_text(output->text) || output->seq == 0 || strcmp(output->connection_nonce, link->nonce) != 0 || strcmp(output->epoch, link->epoch) != 0 || !link->turn_active || strcmp(output->request_id, link->turn_request_id) != 0 || output->seq <= link->last_output_seq) {
+        return false;
+    }
+
+    if (link->turn_id[0] != '\0' && strcmp(link->turn_id, output->turn_id) != 0) {
+        return false;
+    }
+
+    if (link->turn_id[0] == '\0') {
+        copy_bounded(link->turn_id, sizeof(link->turn_id), output->turn_id);
+    }
+
+    /* A QoS 0 gap is noted for display but never changes authority state. */
+    gap = link->last_output_seq != 0 && output->seq > link->last_output_seq + 1;
+    link->last_output_seq = output->seq;
+    link->output_gap = link->output_gap || gap;
+    append_transcript(link, output->text);
+
+    if (gap_detected != NULL) {
+        *gap_detected = gap;
+    }
+
+    return true;
+}
+
+bool remote_link_turn_result(struct remote_link_s* link,
+    const struct remote_turn_result_s* result)
+{
+    if (link == NULL || result == NULL || result->connection_nonce == NULL || result->epoch == NULL || !remote_valid_identifier(result->request_id, REMOTE_REQUEST_ID_MAX) || !remote_valid_identifier(result->turn_id, REMOTE_TURN_ID_MAX) || result->status == NULL || !remote_valid_identifier(result->connection_nonce, REMOTE_NONCE_MAX) || !remote_valid_identifier(result->epoch, REMOTE_EPOCH_MAX) || (strcmp(result->status, "completed") != 0 && strcmp(result->status, "failed") != 0) || strcmp(result->connection_nonce, link->nonce) != 0 || strcmp(result->epoch, link->epoch) != 0 || !link->turn_active || strcmp(result->request_id, link->turn_request_id) != 0) {
+        return false;
+    }
+
+    if (link->turn_id[0] != '\0' && strcmp(link->turn_id, result->turn_id) != 0) {
+        return false;
+    }
+
+    snprintf(link->summary, sizeof(link->summary), "Agent turn %s", result->status);
+    clear_turn(link, false);
+    return true;
+}
+
+/* ── Outbound preconditions ────────────────────────────────────────── */
+
+bool remote_link_can_submit_prompt(const struct remote_link_s* link,
+    const char* text)
+{
+    /* Refusing while has_prompt is set keeps a local tool call from waiting
+     * behind a human permission decision on the remote agent. */
+    return link != NULL && link->state != REMOTE_STATE_OFFLINE && link->chat_supported && strcmp(link->chat_epoch, link->epoch) == 0 && !link->turn_active && !link->has_prompt && text != NULL && text[0] != '\0' && strlen(text) <= REMOTE_PROMPT_TEXT_MAX && remote_valid_utf8(text) && has_nonspace(text);
+}
+
+const char* remote_link_decision_value(const struct remote_link_s* link,
+    enum remote_decision_e decision)
+{
+    if (link == NULL || !link->has_prompt || !remote_valid_identifier(link->nonce, REMOTE_NONCE_MAX) || !remote_valid_identifier(link->epoch, REMOTE_EPOCH_MAX) || !remote_valid_identifier(link->prompt.id, REMOTE_PROMPT_ID_MAX)) {
+        return NULL;
+    }
+
+    if (decision == REMOTE_DECISION_ONCE && link->prompt.can_once) {
+        return "once";
+    }
+
+    if (decision == REMOTE_DECISION_DENY && link->prompt.can_deny) {
+        return "deny";
+    }
+
+    return NULL;
+}
+
+bool remote_link_can_query_usage(const struct remote_link_s* link)
+{
+    return link != NULL && link->state != REMOTE_STATE_OFFLINE && link->epoch[0] != '\0';
+}
+
+bool remote_link_can_select_model(const struct remote_link_s* link,
+    const char* model)
+{
+    /* Refused mid-turn so a reply cannot be produced by two different models.
+     * The remembered list is deliberately not consulted: it can be truncated or
+     * stale, and the bridge is the only authority on what is selectable. */
+    return link != NULL && link->state != REMOTE_STATE_OFFLINE && link->epoch[0] != '\0' && !link->turn_active && remote_valid_identifier(model, REMOTE_MODEL_MAX);
+}
+
+/* Index resolution lives with the console command, against the same copy it
+ * printed — see the note in remote_link.h. */
+
+/* ── Display helpers ───────────────────────────────────────────────── */
+
+bool remote_link_billing_text(const struct remote_link_s* link, char* out,
+    size_t out_size)
+{
+    int written;
+    size_t used;
+
+    if (link == NULL || out == NULL || out_size == 0) {
+        return false;
+    }
+
+    written = snprintf(out, out_size, "Billing: ");
+    if (written < 0 || (size_t)written >= out_size) {
+        return false;
+    }
+    used = (size_t)written;
+
+    /* An absent slot stays empty: never substitute zero, never derive a price
+     * from tokens, never show context-window use as billing. */
+    if (link->usage.has_charge) {
+        written = snprintf(out + used, out_size - used, "%.6g %s",
+            link->usage.charge_amount, link->usage.charge_unit);
+        if (written < 0 || (size_t)written >= out_size - used) {
+            return false;
+        }
+        used += (size_t)written;
+    }
+
+    written = snprintf(out + used, out_size - used, " / ");
+    if (written < 0 || (size_t)written >= out_size - used) {
+        return false;
+    }
+    used += (size_t)written;
+
+    if (link->usage.has_tokens) {
+        written = snprintf(out + used, out_size - used, "%" PRIu64 " tokens",
+            link->usage.total_tokens);
+        if (written < 0 || (size_t)written >= out_size - used) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+const char* remote_state_name(enum remote_state_e state)
+{
+    switch (state) {
+    case REMOTE_STATE_OFFLINE:
+        return "Offline";
+    case REMOTE_STATE_IDLE:
+        return "Idle";
+    case REMOTE_STATE_BUSY:
+        return "Busy";
+    case REMOTE_STATE_ATTENTION:
+        return "Attention";
+    case REMOTE_STATE_RESULT:
+        return "Result";
+    default:
+        return "Unknown";
+    }
+}

--- a/src/remote/remote_link.h
+++ b/src/remote/remote_link.h
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Remote-control link: portable protocol state core.
+ *
+ * This layer owns the authority model of a remote agent session and has no
+ * transport, JSON, or OS dependency. It accepts already-decoded structures
+ * from the codec layer and decides what the device is allowed to believe.
+ *
+ * The remote peer is a PC-side bridge that speaks the frozen DeskMate Link
+ * contract on behalf of an ACP agent (mimocode / kiro-cli). The bridge, not
+ * this device, is the final authority on permission decisions: everything
+ * accepted here is still re-validated remotely.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define REMOTE_NONCE_MAX 48
+#define REMOTE_EPOCH_MAX 48
+#define REMOTE_PROMPT_ID_MAX 40
+#define REMOTE_TOOL_MAX 24
+#define REMOTE_HINT_MAX 96
+#define REMOTE_SUMMARY_MAX 128
+#define REMOTE_BILLING_UNIT_MAX 16
+#define REMOTE_REQUEST_ID_MAX 40
+#define REMOTE_TURN_ID_MAX 40
+#define REMOTE_PROMPT_TEXT_MAX 2048
+#define REMOTE_OUTPUT_TEXT_MAX 1600
+#define REMOTE_TRANSCRIPT_MAX 8192
+
+/* A model identifier is "<provider>/<model>", and the model part may itself
+ * contain slashes ("mify/zhipuai/glm-5.3-flash"). */
+#define REMOTE_MODEL_MAX 64
+
+/* How many models the device remembers so they can be picked by number. The
+ * list is a convenience for typing at a console, not authority: the bridge
+ * decides what is selectable and refuses anything else. Costs
+ * REMOTE_MODEL_OPTIONS_MAX * (REMOTE_MODEL_MAX + 1) bytes of link state. */
+#define REMOTE_MODEL_OPTIONS_MAX 32
+
+/* Authority-snapshot liveness. A session that stops producing snapshots is
+ * treated as down even while the TCP socket looks healthy. */
+#define REMOTE_SNAPSHOT_TIMEOUT_MS 30000U
+
+/* Frozen link limit, in both directions. A peer cannot force an unbounded
+ * allocation on the device, and an outbound message that would exceed it is
+ * refused rather than truncated. Note this is a limit on the encoded form:
+ * escaping can expand a prompt well beyond its own length. */
+#define REMOTE_MESSAGE_MAX 4096
+
+enum remote_state_e {
+    REMOTE_STATE_OFFLINE,
+    REMOTE_STATE_IDLE,
+    REMOTE_STATE_BUSY,
+    REMOTE_STATE_ATTENTION,
+    REMOTE_STATE_RESULT,
+};
+
+enum remote_decision_e {
+    REMOTE_DECISION_ONCE,
+    REMOTE_DECISION_DENY,
+};
+
+enum remote_charge_kind_e {
+    REMOTE_CHARGE_CREDIT,
+    REMOTE_CHARGE_CURRENCY,
+};
+
+enum remote_context_unit_e {
+    REMOTE_CONTEXT_TOKEN,
+    REMOTE_CONTEXT_PERCENT,
+};
+
+struct remote_prompt_s {
+    char id[REMOTE_PROMPT_ID_MAX + 1];
+    char tool[REMOTE_TOOL_MAX + 1];
+    char hint[REMOTE_HINT_MAX + 1];
+    bool can_once;
+    bool can_deny;
+};
+
+struct remote_snapshot_s {
+    const char* connection_nonce;
+    const char* epoch;
+    uint32_t seq;
+    uint8_t running;
+    const char* summary;
+    const struct remote_prompt_s* prompt;
+};
+
+/* Usage is optional telemetry. It is independent from authority snapshots and
+ * carries native units only: charge is the left billing slot and tokens the
+ * right slot. It can never alter a pending permission. */
+struct remote_usage_snapshot_s {
+    const char* connection_nonce;
+    const char* epoch;
+    uint64_t seq;
+    bool has_charge;
+    enum remote_charge_kind_e charge_kind;
+    double charge_amount;
+    const char* charge_unit;
+    bool has_tokens;
+    uint64_t input_tokens;
+    uint64_t output_tokens;
+    uint64_t total_tokens;
+    bool has_context;
+    enum remote_context_unit_e context_unit;
+    double context_used;
+    double context_limit;
+};
+
+struct remote_usage_s {
+    uint64_t last_seq;
+    bool has_charge;
+    enum remote_charge_kind_e charge_kind;
+    double charge_amount;
+    char charge_unit[REMOTE_BILLING_UNIT_MAX + 1];
+    bool has_tokens;
+    uint64_t input_tokens;
+    uint64_t output_tokens;
+    uint64_t total_tokens;
+    bool has_context;
+    enum remote_context_unit_e context_unit;
+    double context_used;
+    double context_limit;
+};
+
+struct remote_hello_ack_s {
+    const char* connection_nonce;
+    const char* epoch;
+    bool chat_turns;
+};
+
+/* The selectable models, as reported by the bridge. `truncated` means the
+ * bridge had more to offer than the link carries, so a name absent from the
+ * list is not proof that it is unavailable. */
+struct remote_models_s {
+    const char* connection_nonce;
+    const char* epoch;
+    const char* current;
+    const char* const* options;
+    size_t count;
+    bool truncated;
+};
+
+struct remote_prompt_ack_s {
+    const char* connection_nonce;
+    const char* epoch;
+    const char* request_id;
+    const char* turn_id;
+    bool accepted;
+};
+
+struct remote_agent_output_s {
+    const char* connection_nonce;
+    const char* epoch;
+    const char* request_id;
+    const char* turn_id;
+    uint32_t seq;
+    const char* text;
+};
+
+struct remote_turn_result_s {
+    const char* connection_nonce;
+    const char* epoch;
+    const char* request_id;
+    const char* turn_id;
+    const char* status;
+};
+
+struct remote_link_s {
+    enum remote_state_e state;
+    char nonce[REMOTE_NONCE_MAX + 1];
+    char epoch[REMOTE_EPOCH_MAX + 1];
+    uint32_t next_seq;
+    char summary[REMOTE_SUMMARY_MAX + 1];
+    struct remote_prompt_s prompt;
+    bool has_prompt;
+    uint32_t last_snapshot_ms;
+    struct remote_usage_s usage;
+    char chat_epoch[REMOTE_EPOCH_MAX + 1];
+    bool chat_supported;
+    bool turn_active;
+    char turn_request_id[REMOTE_REQUEST_ID_MAX + 1];
+    char turn_id[REMOTE_TURN_ID_MAX + 1];
+    uint32_t last_output_seq;
+    bool output_gap;
+    char transcript[REMOTE_TRANSCRIPT_MAX + 1];
+    /* Which model the remote agent is using, and what it may be switched to.
+     * Display and convenience only: the bridge owns the decision and rejects a
+     * value it does not offer, so stale contents here cannot select anything. */
+    char model[REMOTE_MODEL_MAX + 1];
+    char model_options[REMOTE_MODEL_OPTIONS_MAX][REMOTE_MODEL_MAX + 1];
+    uint8_t model_count;
+    bool models_truncated;
+};
+
+/* ── Lifecycle ─────────────────────────────────────────────────────── */
+
+void remote_link_init(struct remote_link_s* link, const char* nonce);
+void remote_link_down(struct remote_link_s* link);
+
+/* ── Inbound authority ─────────────────────────────────────────────── */
+
+bool remote_link_snapshot(struct remote_link_s* link,
+    const struct remote_snapshot_s* snapshot, uint32_t now_ms,
+    bool* display_changed);
+bool remote_link_usage_snapshot(struct remote_link_s* link,
+    const struct remote_usage_snapshot_s* snapshot, bool* display_changed);
+bool remote_link_timeout(struct remote_link_s* link, uint32_t now_ms);
+/* `title` is the human-readable tool name and may be NULL: the bridge sends it
+ * alongside the result, but an older bridge omits it. A raw ACP tool-call id
+ * such as "tooluse_m7MqB5bPlKuDegoWjm6j38" tells the operator nothing, so it is
+ * only a fallback when no title arrived. */
+bool remote_link_tool_result(struct remote_link_s* link,
+    const char* tool_call_id, const char* status, const char* title);
+
+/* Records the model in use and the selectable list. Not authority: it changes
+ * nothing about turns, permissions, or state. An entry that is too long, badly
+ * encoded, or beyond REMOTE_MODEL_OPTIONS_MAX is skipped and the list is marked
+ * truncated rather than rejecting the whole message. */
+bool remote_link_models(struct remote_link_s* link,
+    const struct remote_models_s* models);
+
+/* ── Chat turns ────────────────────────────────────────────────────── */
+
+bool remote_link_hello_ack(struct remote_link_s* link,
+    const struct remote_hello_ack_s* ack);
+/* Reserves the turn slot for `request_id` before the message is handed to a
+ * transport, so a concurrent submit cannot open a second turn. */
+bool remote_link_turn_submitted(struct remote_link_s* link,
+    const char* request_id);
+
+/* Releases a reservation whose send failed. Only clears the turn when it is
+ * still the one identified by `request_id`, so a rollback can never discard a
+ * turn that a later submit opened. */
+bool remote_link_turn_abort(struct remote_link_s* link, const char* request_id);
+bool remote_link_prompt_ack(struct remote_link_s* link,
+    const struct remote_prompt_ack_s* ack);
+bool remote_link_agent_output(struct remote_link_s* link,
+    const struct remote_agent_output_s* output, bool* gap_detected);
+bool remote_link_turn_result(struct remote_link_s* link,
+    const struct remote_turn_result_s* result);
+
+/* ── Outbound preconditions (codec serializes only what these allow) ─ */
+
+/* True when a new chat turn may be submitted with this exact text. Rejects
+ * while a turn is active or a permission is pending, so a local LLM tool call
+ * can never queue behind a human decision. */
+bool remote_link_can_submit_prompt(const struct remote_link_s* link,
+    const char* text);
+
+/* Returns "once" / "deny" when the pending prompt permits that decision,
+ * NULL otherwise. */
+const char* remote_link_decision_value(const struct remote_link_s* link,
+    enum remote_decision_e decision);
+
+/* True when a read-only usage query may be sent. */
+bool remote_link_can_query_usage(const struct remote_link_s* link);
+
+/* True when `model` may be requested. Refused while a turn is running: the
+ * model that started a turn should be the one that finishes it. The list held
+ * here is not consulted — it may be truncated or stale, and the bridge is the
+ * only authority on what is selectable. */
+bool remote_link_can_select_model(const struct remote_link_s* link,
+    const char* model);
+
+/* Console index resolution deliberately lives with the command that prints the
+ * numbered list: remote_session_model_view returns the names and their order in
+ * one consistent copy, so resolving a number against that same copy cannot pick
+ * a different entry than the one displayed. */
+
+/* ── Display helpers ───────────────────────────────────────────────── */
+
+/* Renders "Billing: <charge> / <tokens>". Either slot may be empty; a missing
+ * value is never substituted with zero and tokens are never priced. */
+bool remote_link_billing_text(const struct remote_link_s* link, char* out,
+    size_t out_size);
+const char* remote_state_name(enum remote_state_e state);
+
+/* Shared validators, also used by the codec layer. */
+bool remote_valid_utf8(const char* text);
+bool remote_valid_identifier(const char* value, size_t maximum);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/remote/remote_link_mqtt.c
+++ b/src/remote/remote_link_mqtt.c
@@ -1,0 +1,416 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "remote/remote_link_mqtt.h"
+#include "remote/remote_codec.h"
+
+#include "agent_compat.h"
+
+#include <mqtt.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+static const char* TAG = "remote";
+
+/* Room for one full-size link message plus MQTT framing. */
+#define REMOTE_MQTT_BUFFER_SIZE (REMOTE_MESSAGE_MAX + 512)
+#define REMOTE_MQTT_TOPIC_MAX 160
+#define REMOTE_MQTT_KEEPALIVE 30
+#define REMOTE_MQTT_SYNC_INTERVAL_MS 100
+#define REMOTE_MQTT_RETRY_DELAY_S 1
+#define REMOTE_MQTT_CONNECT_TIMEOUT_MS 5000
+
+/* 18 random bytes rendered as hex. Long enough that a stale bridge session
+ * cannot be replayed against a new connection. */
+#define REMOTE_MQTT_NONCE_BYTES 18
+
+struct remote_mqtt_s {
+    struct mqtt_client mqtt;
+    struct remote_session_s* session;
+    struct remote_transport_s transport;
+    char host[REMOTE_MQTT_HOST_MAX + 1];
+    char port[REMOTE_MQTT_PORT_MAX + 1];
+    char username[REMOTE_MQTT_USER_MAX + 1];
+    char password[REMOTE_MQTT_PASSWORD_MAX + 1];
+    char device_id[REMOTE_MQTT_DEVICE_ID_MAX + 1];
+    char to_bridge[REMOTE_MQTT_TOPIC_MAX];
+    char to_device[REMOTE_MQTT_TOPIC_MAX];
+    uint8_t sendbuf[REMOTE_MQTT_BUFFER_SIZE] __attribute__((aligned(sizeof(uintptr_t))));
+    uint8_t recvbuf[REMOTE_MQTT_BUFFER_SIZE];
+};
+
+/* How long remote_link_mqtt_stop() waits for the loop to leave. A connect
+ * attempt sitting in poll() can outlast this; the restart guard below is what
+ * makes that safe rather than racy. */
+#define REMOTE_MQTT_STOP_WAIT_S 2
+
+/* One remote session per device, so a single static instance avoids ~9 KiB of
+ * heap churn across reconnects. Because the instance is shared, only one loop
+ * may own it at a time — see g_loop_active. */
+static struct remote_mqtt_s g_mqtt;
+static volatile bool g_running;
+
+/* Ownership of the static transport above. A stop() followed immediately by a
+ * start() (as an NSH reconfigure does) must not put two loops on it. */
+static pthread_mutex_t g_state_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t g_state_cond = PTHREAD_COND_INITIALIZER;
+static bool g_loop_active;
+
+static void release_loop(void)
+{
+    pthread_mutex_lock(&g_state_lock);
+    g_loop_active = false;
+    pthread_cond_broadcast(&g_state_cond);
+    pthread_mutex_unlock(&g_state_lock);
+}
+
+static uint32_t now_ms(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint32_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+}
+
+/* ── Transport operation ───────────────────────────────────────────── */
+
+/* Called by the session with its lock released, so taking MQTT-C's client
+ * mutex here cannot invert lock order against the inbound path. */
+static bool send_json(void* context, const char* json, size_t length)
+{
+    struct remote_mqtt_s* transport = context;
+
+    if (transport == NULL || length == 0 || length > REMOTE_MESSAGE_MAX) {
+        return false;
+    }
+
+    return mqtt_publish(&transport->mqtt, transport->to_bridge, json, length,
+               MQTT_PUBLISH_QOS_0)
+        == MQTT_OK;
+}
+
+static const struct remote_transport_ops_s g_transport_ops = {
+    .send_json = send_json,
+};
+
+/* ── Inbound ───────────────────────────────────────────────────────── */
+
+/* MQTT-C runs this while holding its own client mutex. Everything below only
+ * takes the session lock, never publishes. */
+static void publish_callback(void** state, struct mqtt_response_publish* published)
+{
+    struct remote_mqtt_s* transport = (state != NULL) ? *state : NULL;
+
+    if (transport == NULL || transport->session == NULL) {
+        return;
+    }
+
+    /* Ignore anything that is not our exact inbound topic: a wildcard
+     * subscription elsewhere on the broker must not feed this session. */
+    if (published->topic_name_size != strlen(transport->to_device) || memcmp(published->topic_name, transport->to_device, published->topic_name_size) != 0) {
+        return;
+    }
+
+    remote_codec_receive(transport->session,
+        published->application_message,
+        published->application_message_size, now_ms());
+}
+
+/* ── Setup helpers ─────────────────────────────────────────────────── */
+
+static bool copy_config(const struct remote_mqtt_config_s* config,
+    struct remote_mqtt_s* transport)
+{
+    const char* prefix = (config->topic_prefix != NULL && config->topic_prefix[0] != '\0')
+        ? config->topic_prefix
+        : REMOTE_MQTT_TOPIC_PREFIX_DEFAULT;
+    int written;
+
+    if (config->host == NULL || config->host[0] == '\0' || config->device_id == NULL || config->device_id[0] == '\0' || strlen(config->host) > REMOTE_MQTT_HOST_MAX || strlen(config->device_id) > REMOTE_MQTT_DEVICE_ID_MAX || strlen(prefix) > REMOTE_MQTT_TOPIC_PREFIX_MAX) {
+        return false;
+    }
+
+    /* A wildcard in the prefix would subscribe this device to other devices'
+     * traffic, so reject it rather than sanitising it. */
+    if (strchr(prefix, '+') != NULL || strchr(prefix, '#') != NULL || strchr(config->device_id, '+') != NULL || strchr(config->device_id, '#') != NULL || strchr(config->device_id, '/') != NULL) {
+        return false;
+    }
+
+    if ((config->port != NULL && strlen(config->port) > REMOTE_MQTT_PORT_MAX) || (config->username != NULL && strlen(config->username) > REMOTE_MQTT_USER_MAX) || (config->password != NULL && strlen(config->password) > REMOTE_MQTT_PASSWORD_MAX)) {
+        return false;
+    }
+
+    strcpy(transport->host, config->host);
+    strcpy(transport->device_id, config->device_id);
+    snprintf(transport->port, sizeof(transport->port), "%s",
+        (config->port != NULL && config->port[0] != '\0') ? config->port : "1883");
+    snprintf(transport->username, sizeof(transport->username), "%s",
+        config->username != NULL ? config->username : "");
+    snprintf(transport->password, sizeof(transport->password), "%s",
+        config->password != NULL ? config->password : "");
+
+    written = snprintf(transport->to_bridge, sizeof(transport->to_bridge),
+        "%s/%s/device-to-bridge", prefix, transport->device_id);
+    if (written < 0 || (size_t)written >= sizeof(transport->to_bridge)) {
+        return false;
+    }
+
+    written = snprintf(transport->to_device, sizeof(transport->to_device),
+        "%s/%s/bridge-to-device", prefix, transport->device_id);
+    return written > 0 && (size_t)written < sizeof(transport->to_device);
+}
+
+/* MQTT-C requires a non-blocking socket. */
+static int connect_socket(const char* host, const char* port)
+{
+    struct addrinfo hints;
+    struct addrinfo* result;
+    struct addrinfo* item;
+    int fd = -1;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    if (getaddrinfo(host, port, &hints, &result) != 0) {
+        syslog(LOG_ERR, "[%s] DNS resolve failed: %s\n", TAG, host);
+        return -1;
+    }
+
+    for (item = result; item != NULL; item = item->ai_next) {
+        int flags;
+
+        fd = socket(item->ai_family, item->ai_socktype, item->ai_protocol);
+        if (fd < 0) {
+            continue;
+        }
+
+        flags = fcntl(fd, F_GETFL, 0);
+        if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+            close(fd);
+            fd = -1;
+            continue;
+        }
+
+        if (connect(fd, item->ai_addr, item->ai_addrlen) == 0) {
+            break;
+        }
+
+        if (errno == EINPROGRESS) {
+            struct pollfd entry;
+
+            entry.fd = fd;
+            entry.events = POLLOUT;
+            entry.revents = 0;
+            if (poll(&entry, 1, REMOTE_MQTT_CONNECT_TIMEOUT_MS) > 0) {
+                int error = 0;
+                socklen_t error_size = sizeof(error);
+
+                if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &error_size) == 0 && error == 0) {
+                    break;
+                }
+            }
+        }
+
+        close(fd);
+        fd = -1;
+    }
+
+    freeaddrinfo(result);
+    return fd;
+}
+
+static bool make_nonce(char* out, size_t out_size)
+{
+    unsigned char bytes[REMOTE_MQTT_NONCE_BYTES];
+    size_t index;
+
+    if (out_size < sizeof(bytes) * 2 + 1) {
+        return false;
+    }
+
+    /* A predictable nonce would let a stale bridge session be replayed, so a
+     * failure here aborts the connection instead of falling back to time(). */
+    if (agent_secure_random(bytes, sizeof(bytes)) != 0) {
+        syslog(LOG_ERR, "[%s] secure random unavailable, cannot open session\n", TAG);
+        return false;
+    }
+
+    for (index = 0; index < sizeof(bytes); index++) {
+        snprintf(&out[index * 2], 3, "%02x", bytes[index]);
+    }
+
+    return true;
+}
+
+/* ── Run loop ──────────────────────────────────────────────────────── */
+
+int remote_link_mqtt_run(const struct remote_mqtt_config_s* config,
+    struct remote_session_s* session)
+{
+    struct remote_mqtt_s* transport = &g_mqtt;
+    char client_id[REMOTE_MQTT_DEVICE_ID_MAX + 24];
+    char nonce[REMOTE_NONCE_MAX + 1];
+    int written;
+
+    if (config == NULL || session == NULL) {
+        return ERROR;
+    }
+
+    /* Claim the shared transport before anything writes to it. copy_config()
+     * targets g_mqtt, so without this even a rejected start would scribble on
+     * the config of a loop that is still running. */
+    pthread_mutex_lock(&g_state_lock);
+    if (g_loop_active) {
+        pthread_mutex_unlock(&g_state_lock);
+        syslog(LOG_WARNING,
+            "[%s] a transport loop is still active, not starting another\n", TAG);
+        return ERROR;
+    }
+    g_loop_active = true;
+    pthread_mutex_unlock(&g_state_lock);
+
+    if (!copy_config(config, transport)) {
+        syslog(LOG_ERR, "[%s] invalid MQTT configuration\n", TAG);
+        release_loop();
+        return ERROR;
+    }
+
+    written = snprintf(client_id, sizeof(client_id), "remote-ctrl-%s",
+        transport->device_id);
+    if (written < 0 || (size_t)written >= sizeof(client_id)) {
+        release_loop();
+        return ERROR;
+    }
+
+    transport->session = session;
+    transport->transport.ops = &g_transport_ops;
+    transport->transport.context = transport;
+    g_running = true;
+
+    while (g_running) {
+        int fd = connect_socket(transport->host, transport->port);
+
+        if (fd < 0) {
+            syslog(LOG_WARNING, "[%s] broker connect failed: %s:%s\n", TAG,
+                transport->host, transport->port);
+            sleep(REMOTE_MQTT_RETRY_DELAY_S);
+            continue;
+        }
+
+        /* Every reconnect is a new session: fresh nonce, fresh handshake, and
+         * Offline until a matching snapshot arrives. This is why the transport
+         * does not use mqtt_init_reconnect — the boundary has to be visible. */
+        if (!make_nonce(nonce, sizeof(nonce))) {
+            close(fd);
+            sleep(REMOTE_MQTT_RETRY_DELAY_S);
+            continue;
+        }
+
+        remote_session_new_connection(session, nonce);
+
+        mqtt_init(&transport->mqtt, fd, transport->sendbuf,
+            sizeof(transport->sendbuf), transport->recvbuf,
+            sizeof(transport->recvbuf), publish_callback);
+        transport->mqtt.publish_response_callback_state = transport;
+
+        if (mqtt_connect(&transport->mqtt, client_id, NULL, NULL, 0,
+                transport->username[0] ? transport->username : NULL,
+                transport->password[0] ? transport->password : NULL,
+                MQTT_CONNECT_CLEAN_SESSION, REMOTE_MQTT_KEEPALIVE)
+                != MQTT_OK
+            || mqtt_subscribe(&transport->mqtt, transport->to_device, 0) != MQTT_OK) {
+            syslog(LOG_WARNING, "[%s] MQTT connect or subscribe failed\n", TAG);
+            close(fd);
+            sleep(REMOTE_MQTT_RETRY_DELAY_S);
+            continue;
+        }
+
+        /* The transport must be active before hello: the handshake goes out
+         * through the same path as every other outbound message. */
+        remote_session_set_active_transport(session, &transport->transport);
+
+        if (!remote_session_send_hello(session)) {
+            syslog(LOG_WARNING, "[%s] hello publish failed\n", TAG);
+            remote_session_set_active_transport(session, NULL);
+            close(fd);
+            sleep(REMOTE_MQTT_RETRY_DELAY_S);
+            continue;
+        }
+
+        syslog(LOG_INFO, "[%s] connected as %s via %s:%s\n", TAG,
+            transport->device_id, transport->host, transport->port);
+
+        while (g_running && mqtt_sync(&transport->mqtt) == MQTT_OK && transport->mqtt.error == MQTT_OK) {
+            /* Independent of TCP health: a bridge that stops sending snapshots
+             * drops the session back to Offline. */
+            remote_session_timeout(session, now_ms());
+            usleep(REMOTE_MQTT_SYNC_INTERVAL_MS * 1000);
+        }
+
+        syslog(LOG_INFO, "[%s] disconnected\n", TAG);
+        remote_session_link_down(session);
+        remote_session_set_active_transport(session, NULL);
+        close(fd);
+
+        if (g_running) {
+            sleep(REMOTE_MQTT_RETRY_DELAY_S);
+        }
+    }
+
+    remote_session_link_down(session);
+    remote_session_set_active_transport(session, NULL);
+    syslog(LOG_INFO, "[%s] transport loop exited\n", TAG);
+    release_loop();
+    return OK;
+}
+
+void remote_link_mqtt_stop(void)
+{
+    struct timespec deadline;
+
+    g_running = false;
+
+    pthread_mutex_lock(&g_state_lock);
+    if (!g_loop_active) {
+        pthread_mutex_unlock(&g_state_lock);
+        return;
+    }
+
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += REMOTE_MQTT_STOP_WAIT_S;
+
+    while (g_loop_active) {
+        if (pthread_cond_timedwait(&g_state_cond, &g_state_lock, &deadline) == ETIMEDOUT) {
+            /* Most likely parked in a connect attempt. Returning here is safe
+             * because a restart is refused while the loop still owns the
+             * transport. */
+            syslog(LOG_WARNING, "[%s] transport loop still winding down\n", TAG);
+            break;
+        }
+    }
+
+    pthread_mutex_unlock(&g_state_lock);
+}

--- a/src/remote/remote_link_mqtt.h
+++ b/src/remote/remote_link_mqtt.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* MQTT transport for the remote-control link.
+ *
+ * Deliberately does not reuse mqtt_channel.c: that channel hands reconnection
+ * to MQTT-C via mqtt_init_reconnect, but this link must mint a fresh
+ * connection nonce and redo the hello handshake on every reconnect, so the
+ * reconnect boundary has to be visible here.
+ */
+
+#pragma once
+
+#include "remote/remote_session.h"
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define REMOTE_MQTT_HOST_MAX 127
+#define REMOTE_MQTT_PORT_MAX 5
+#define REMOTE_MQTT_USER_MAX 63
+#define REMOTE_MQTT_PASSWORD_MAX 127
+#define REMOTE_MQTT_DEVICE_ID_MAX 32
+#define REMOTE_MQTT_TOPIC_PREFIX_MAX 32
+
+/* Wire-compatible default with the PC bridge's --topic-prefix. */
+#define REMOTE_MQTT_TOPIC_PREFIX_DEFAULT "deskmate"
+
+struct remote_mqtt_config_s {
+    const char* host;
+    const char* port;
+    const char* username;
+    const char* password;
+    const char* device_id;
+    const char* topic_prefix; /* NULL selects the default */
+};
+
+/* Runs the connect / handshake / sync / reconnect loop until
+ * remote_link_mqtt_stop(). Blocks, so call it from a dedicated thread.
+ *
+ * Returns ERROR on invalid configuration, ERROR if a previous loop is still
+ * winding down, and OK after a requested stop. The transport keeps its buffers
+ * in one static instance, so refusing the overlap is what stops two loops from
+ * sharing them. */
+int remote_link_mqtt_run(const struct remote_mqtt_config_s* config,
+    struct remote_session_s* session);
+
+/* Asks the loop to exit and waits briefly for it to do so. Safe to call from
+ * another thread.
+ *
+ * The wait is bounded: a connect attempt already inside poll() can outlast it.
+ * When that happens this returns anyway and an immediate restart is refused by
+ * remote_link_mqtt_run() rather than allowed to race. */
+void remote_link_mqtt_stop(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/remote/remote_session.c
+++ b/src/remote/remote_session.c
@@ -1,0 +1,545 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "remote/remote_session.h"
+#include "remote/remote_codec.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+/* ── Internal helpers (all called with the lock held) ──────────────── */
+
+/* Runs the presentation hook. Called under the lock, so the handler must not
+ * re-enter the session. Handlers are expected to be cheap: anything that can
+ * block for long delays the transport thread. */
+static void emit(struct remote_session_s* session, enum remote_event_e event,
+    const char* text)
+{
+    if (session->on_event != NULL) {
+        session->on_event(session->event_context, event, text);
+    }
+}
+
+static void clear_latch(struct remote_session_s* session)
+{
+    session->decision_in_flight = false;
+    session->decided_prompt_id[0] = '\0';
+}
+
+static bool make_request_id(struct remote_session_s* session, char* out,
+    size_t out_size)
+{
+    int written;
+
+    session->next_request_number++;
+    written = snprintf(out, out_size, "r-%.24s-%08" PRIx32,
+        session->link.nonce, session->next_request_number);
+    return written > 0 && (size_t)written < out_size;
+}
+
+/* Snapshots the active transport pointer so the send can happen after the lock
+ * is released. The pointed-to transport outlives the session by construction
+ * (it is owned by the transport module), and its send path re-checks its own
+ * connection state, so a link that drops mid-send fails rather than misbehaves. */
+static struct remote_transport_s* current_transport(
+    struct remote_session_s* session)
+{
+    return session->active_transport;
+}
+
+/* ── Lifecycle ─────────────────────────────────────────────────────── */
+
+void remote_session_init(struct remote_session_s* session, const char* nonce)
+{
+    /* memset would clear an initialised mutex, so the lock is created after it.
+     * This must complete before any other thread can reach the session. */
+    memset(session, 0, sizeof(*session));
+    pthread_mutex_init(&session->lock, NULL);
+    remote_link_init(&session->link, nonce);
+}
+
+void remote_session_destroy(struct remote_session_s* session)
+{
+    pthread_mutex_destroy(&session->lock);
+}
+
+void remote_session_set_event_handler(struct remote_session_s* session,
+    remote_event_fn on_event, void* context)
+{
+    pthread_mutex_lock(&session->lock);
+    session->on_event = on_event;
+    session->event_context = context;
+    pthread_mutex_unlock(&session->lock);
+}
+
+void remote_session_new_connection(struct remote_session_s* session,
+    const char* nonce)
+{
+    pthread_mutex_lock(&session->lock);
+    remote_link_init(&session->link, nonce);
+    clear_latch(session);
+    pthread_mutex_unlock(&session->lock);
+}
+
+void remote_session_set_active_transport(struct remote_session_s* session,
+    struct remote_transport_s* transport)
+{
+    pthread_mutex_lock(&session->lock);
+    session->active_transport = transport;
+    pthread_mutex_unlock(&session->lock);
+}
+
+void remote_session_link_down(struct remote_session_s* session)
+{
+    pthread_mutex_lock(&session->lock);
+    remote_link_down(&session->link);
+    clear_latch(session);
+    pthread_mutex_unlock(&session->lock);
+}
+
+/* ── Inbound ───────────────────────────────────────────────────────── */
+
+bool remote_session_snapshot(struct remote_session_s* session,
+    const struct remote_snapshot_s* snapshot, uint32_t now_ms,
+    bool* display_changed)
+{
+    bool changed = false;
+    bool accepted;
+
+    pthread_mutex_lock(&session->lock);
+    accepted = remote_link_snapshot(&session->link, snapshot, now_ms, &changed);
+    if (accepted) {
+        /* A later authoritative snapshot is the only thing that clears the
+         * latch: either the prompt is gone or it was replaced. */
+        if (!session->link.has_prompt || strcmp(session->link.prompt.id, session->decided_prompt_id) != 0) {
+            clear_latch(session);
+        }
+
+        if (changed) {
+            emit(session, REMOTE_EVENT_STATE, session->link.summary);
+        }
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    if (display_changed != NULL) {
+        *display_changed = changed;
+    }
+
+    return accepted;
+}
+
+bool remote_session_usage_snapshot(struct remote_session_s* session,
+    const struct remote_usage_snapshot_s* snapshot, bool* display_changed)
+{
+    char text[96];
+    bool changed = false;
+    bool accepted;
+
+    pthread_mutex_lock(&session->lock);
+    accepted = remote_link_usage_snapshot(&session->link, snapshot, &changed);
+    if (accepted && changed && remote_link_billing_text(&session->link, text, sizeof(text))) {
+        emit(session, REMOTE_EVENT_BILLING, text);
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    if (display_changed != NULL) {
+        *display_changed = changed;
+    }
+
+    return accepted;
+}
+
+bool remote_session_tool_result(struct remote_session_s* session,
+    const char* connection_nonce, const char* epoch, const char* tool_call_id,
+    const char* status, const char* title)
+{
+    bool accepted = false;
+
+    if (session == NULL || connection_nonce == NULL || epoch == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    /* Session binding is checked here rather than by the caller so no reader
+     * touches link state without the lock. */
+    if (strcmp(connection_nonce, session->link.nonce) == 0 && strcmp(epoch, session->link.epoch) == 0) {
+        accepted = remote_link_tool_result(&session->link, tool_call_id, status,
+            title);
+    }
+
+    if (accepted) {
+        clear_latch(session);
+        emit(session, REMOTE_EVENT_STATE, session->link.summary);
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    return accepted;
+}
+
+bool remote_session_timeout(struct remote_session_s* session, uint32_t now_ms)
+{
+    bool expired;
+
+    pthread_mutex_lock(&session->lock);
+    expired = remote_link_timeout(&session->link, now_ms);
+    if (expired) {
+        clear_latch(session);
+        emit(session, REMOTE_EVENT_STATE, session->link.summary);
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    return expired;
+}
+
+bool remote_session_hello_ack(struct remote_session_s* session,
+    const struct remote_hello_ack_s* ack)
+{
+    bool accepted;
+
+    if (session == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    accepted = remote_link_hello_ack(&session->link, ack);
+    pthread_mutex_unlock(&session->lock);
+
+    return accepted;
+}
+
+bool remote_session_prompt_ack(struct remote_session_s* session,
+    const struct remote_prompt_ack_s* ack)
+{
+    bool accepted;
+
+    if (session == NULL || ack == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    accepted = remote_link_prompt_ack(&session->link, ack);
+    if (accepted && !ack->accepted) {
+        emit(session, REMOTE_EVENT_PROMPT_REJECTED, NULL);
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    return accepted;
+}
+
+bool remote_session_agent_output(struct remote_session_s* session,
+    const struct remote_agent_output_s* output, bool* gap_detected)
+{
+    bool gap = false;
+    bool accepted;
+
+    if (session == NULL || output == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    accepted = remote_link_agent_output(&session->link, output, &gap);
+    if (accepted) {
+        if (gap) {
+            emit(session, REMOTE_EVENT_OUTPUT_GAP, NULL);
+        }
+        emit(session, REMOTE_EVENT_AGENT_OUTPUT, output->text);
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    if (gap_detected != NULL) {
+        *gap_detected = gap;
+    }
+
+    return accepted;
+}
+
+bool remote_session_models(struct remote_session_s* session,
+    const struct remote_models_s* models)
+{
+    char previous[REMOTE_MODEL_MAX + 1];
+    bool accepted;
+
+    if (session == NULL || models == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    strcpy(previous, session->link.model);
+    accepted = remote_link_models(&session->link, models);
+    /* Only a real change is announced. The bridge repeats this message on every
+     * handshake, and echoing an unchanged model each time would be noise. */
+    if (accepted && strcmp(previous, session->link.model) != 0) {
+        emit(session, REMOTE_EVENT_MODEL, session->link.model);
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    return accepted;
+}
+
+bool remote_session_turn_result(struct remote_session_s* session,
+    const struct remote_turn_result_s* result)
+{
+    bool accepted;
+
+    if (session == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    accepted = remote_link_turn_result(&session->link, result);
+    if (accepted) {
+        /* Transcript before the outcome, so the reply reads above the line that
+         * says the turn ended. remote_link_turn_result keeps the transcript, so
+         * it is still intact here. Skipped when empty, which is what a turn that
+         * only ran tools produces. */
+        if (session->link.transcript[0] != '\0') {
+            emit(session, REMOTE_EVENT_TURN_TRANSCRIPT, session->link.transcript);
+        }
+        emit(session, REMOTE_EVENT_TURN_RESULT, session->link.summary);
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    return accepted;
+}
+
+/* ── Outbound ──────────────────────────────────────────────────────── */
+
+/* Every path below follows the same shape: serialize under the lock, release,
+ * then send. Holding the lock across a transport call would invert lock order
+ * against the inbound path, where MQTT-C already holds its client mutex when it
+ * delivers a message. */
+
+bool remote_session_send_hello(struct remote_session_s* session)
+{
+    char message[REMOTE_CODEC_HELLO_BUF];
+    struct remote_transport_s* transport;
+    bool built;
+
+    if (session == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    built = remote_codec_build_hello(&session->link, message, sizeof(message));
+    transport = current_transport(session);
+    pthread_mutex_unlock(&session->lock);
+
+    return built && remote_transport_send(transport, message, strlen(message));
+}
+
+bool remote_session_decide(struct remote_session_s* session,
+    enum remote_decision_e decision)
+{
+    char message[REMOTE_CODEC_DECISION_BUF];
+    char prompt_id[REMOTE_PROMPT_ID_MAX + 1];
+    struct remote_transport_s* transport;
+    bool built = false;
+
+    if (session == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    /* One decision per prompt. Repeat local input is refused here; the bridge
+     * independently rejects duplicate, stale, or mismatched decisions. */
+    if (!session->decision_in_flight) {
+        built = remote_codec_build_decision(&session->link, decision, message, sizeof(message));
+    }
+
+    if (built) {
+        /* Claim the latch before releasing the lock so a second decision
+         * cannot be built for the same prompt while this one is in flight. */
+        strcpy(session->decided_prompt_id, session->link.prompt.id);
+        strcpy(prompt_id, session->link.prompt.id);
+        session->decision_in_flight = true;
+    }
+    transport = current_transport(session);
+    pthread_mutex_unlock(&session->lock);
+
+    if (!built) {
+        return false;
+    }
+
+    if (remote_transport_send(transport, message, strlen(message))) {
+        return true;
+    }
+
+    /* The decision never left the device, so release the claim — but only if
+     * it is still the one made above. */
+    pthread_mutex_lock(&session->lock);
+    if (session->decision_in_flight && strcmp(session->decided_prompt_id, prompt_id) == 0) {
+        clear_latch(session);
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    return false;
+}
+
+bool remote_session_select_model(struct remote_session_s* session,
+    const char* model)
+{
+    char message[REMOTE_CODEC_MODEL_SELECT_BUF];
+    struct remote_transport_s* transport;
+    bool built;
+
+    if (session == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    built = remote_codec_build_model_select(&session->link, model, message,
+        sizeof(message));
+    transport = current_transport(session);
+    pthread_mutex_unlock(&session->lock);
+
+    /* Nothing local to roll back: the model in use belongs to the bridge, and
+     * this device only ever learns it from a `models` message. A send that
+     * fails simply leaves the previously reported model in place. */
+    return built && remote_transport_send(transport, message, strlen(message));
+}
+
+bool remote_session_query_usage(struct remote_session_s* session)
+{
+    char message[REMOTE_CODEC_USAGE_QUERY_BUF];
+    struct remote_transport_s* transport;
+    bool built;
+
+    if (session == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    built = remote_codec_build_usage_query(&session->link, message, sizeof(message));
+    transport = current_transport(session);
+    pthread_mutex_unlock(&session->lock);
+
+    /* Read-only: nothing to roll back if the send fails. */
+    return built && remote_transport_send(transport, message, strlen(message));
+}
+
+bool remote_session_submit_prompt(struct remote_session_s* session,
+    const char* text)
+{
+    char request_id[REMOTE_REQUEST_ID_MAX + 1];
+    struct remote_transport_s* transport;
+    size_t length = 0;
+    bool reserved = false;
+
+    if (session == NULL) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    /* The precondition is checked before minting an id so a submit refused
+     * locally does not consume one. A submit that fails later, at the transport,
+     * keeps its id burnt on purpose: the message may already have reached the
+     * bridge, and reusing the id could conflate two turns. */
+    if (remote_link_can_submit_prompt(&session->link, text) && make_request_id(session, request_id, sizeof(request_id)) && remote_codec_build_prompt_submit(&session->link, request_id, text, session->prompt_message, sizeof(session->prompt_message))) {
+        /* Reserve the turn while still holding the lock: the reservation is
+         * what makes a concurrent submit fail instead of opening a second turn,
+         * and it also protects the shared staging buffer. */
+        reserved = remote_link_turn_submitted(&session->link, request_id);
+        length = strlen(session->prompt_message);
+    }
+    transport = current_transport(session);
+    pthread_mutex_unlock(&session->lock);
+
+    if (!reserved) {
+        return false;
+    }
+
+    /* Safe to read the staging buffer with the lock released: the reservation
+     * above set turn_active, and remote_link_can_submit_prompt refuses while
+     * that holds, so no concurrent submit can reach the encoder. */
+    if (remote_transport_send(transport, session->prompt_message, length)) {
+        return true;
+    }
+
+    /* The turn never left the device, so free the slot again. Aborting is
+     * request-id scoped and does nothing if an ack already closed the turn. */
+    pthread_mutex_lock(&session->lock);
+    remote_link_turn_abort(&session->link, request_id);
+    pthread_mutex_unlock(&session->lock);
+    return false;
+}
+
+/* ── Status ────────────────────────────────────────────────────────── */
+
+void remote_session_status(struct remote_session_s* session,
+    struct remote_status_s* out)
+{
+    memset(out, 0, sizeof(*out));
+
+    pthread_mutex_lock(&session->lock);
+    out->state = session->link.state;
+    memcpy(out->summary, session->link.summary, sizeof(out->summary));
+    out->has_prompt = session->link.has_prompt;
+    out->prompt = session->link.prompt;
+    out->decision_in_flight = session->decision_in_flight;
+    out->turn_active = session->link.turn_active;
+    out->chat_supported = session->link.chat_supported;
+    strcpy(out->model, session->link.model);
+    if (!remote_link_billing_text(&session->link, out->billing, sizeof(out->billing))) {
+        out->billing[0] = '\0';
+    }
+    pthread_mutex_unlock(&session->lock);
+}
+
+bool remote_session_transcript(struct remote_session_s* session, char* out,
+    size_t out_size)
+{
+    bool fits;
+
+    if (session == NULL || out == NULL || out_size == 0) {
+        return false;
+    }
+
+    pthread_mutex_lock(&session->lock);
+    fits = strlen(session->link.transcript) < out_size;
+    if (fits) {
+        strcpy(out, session->link.transcript);
+    } else {
+        out[0] = '\0';
+    }
+    pthread_mutex_unlock(&session->lock);
+
+    return fits;
+}
+
+void remote_session_model_view(struct remote_session_s* session,
+    struct remote_model_view_s* out)
+{
+    if (out == NULL) {
+        return;
+    }
+
+    memset(out, 0, sizeof(*out));
+    if (session == NULL) {
+        return;
+    }
+
+    /* Copied in one pass under the lock: a listing that read the names one at a
+     * time could show entries from two different bridge updates and number them
+     * inconsistently with what a following select would resolve. */
+    pthread_mutex_lock(&session->lock);
+    strcpy(out->current, session->link.model);
+    memcpy(out->options, session->link.model_options, sizeof(out->options));
+    out->count = session->link.model_count;
+    out->truncated = session->link.models_truncated;
+    out->turn_active = session->link.turn_active;
+    pthread_mutex_unlock(&session->lock);
+}

--- a/src/remote/remote_session.h
+++ b/src/remote/remote_session.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Remote-control session: owns one protocol link plus its active transport,
+ * and holds the local decision latch. Everything that leaves the device goes
+ * through here.
+ *
+ * Concurrency. A session is reached from several threads: the transport thread
+ * applies inbound messages, while NSH commands and tool calls submit outbound
+ * ones. Every function here locks internally, so callers need no lock of their
+ * own. Two rules keep that safe:
+ *
+ *   1. The transport is never called with the session lock held. MQTT-C runs
+ *      the inbound callback while holding its own client mutex, so taking the
+ *      session lock inside a publish and the MQTT mutex inside a send would
+ *      invert lock order between the two paths. Outbound calls therefore build
+ *      the message under the lock, release it, and only then send.
+ *   2. An event handler runs with the lock held and must not call back into
+ *      any remote_session_* function.
+ */
+
+#pragma once
+
+#include "remote/remote_link.h"
+#include "remote/remote_transport.h"
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum remote_event_e {
+    REMOTE_EVENT_STATE, /* state or summary changed */
+    REMOTE_EVENT_AGENT_OUTPUT, /* one chunk of remote agent text */
+    REMOTE_EVENT_OUTPUT_GAP, /* QoS 0 loss noted, authority unchanged */
+    /* The whole reply, once, when the turn ends. Chunks arrive too small and too
+     * often to read as they stream, so the link accumulates them and the reply is
+     * presented as one piece here. Carries the transcript itself, so a handler
+     * never has to call back into the session to fetch it. */
+    REMOTE_EVENT_TURN_TRANSCRIPT,
+    /* The remote agent's model changed. Emitted only on a real change, so a
+     * switch made on the PC side is visible here without polling. */
+    REMOTE_EVENT_MODEL,
+    REMOTE_EVENT_TURN_RESULT,
+    REMOTE_EVENT_PROMPT_REJECTED,
+    REMOTE_EVENT_BILLING,
+};
+
+/* Presentation hook. The session never prints: the channel decides whether an
+ * event goes to syslog, the message bus, or a UI. Invoked with the session
+ * lock held, so it must not re-enter the session. */
+typedef void (*remote_event_fn)(void* context, enum remote_event_e event,
+    const char* text);
+
+/* Consistent view of the session for display, copied out under the lock. */
+struct remote_status_s {
+    enum remote_state_e state;
+    char summary[REMOTE_SUMMARY_MAX + 1];
+    char billing[96];
+    bool has_prompt;
+    struct remote_prompt_s prompt;
+    bool decision_in_flight;
+    bool turn_active;
+    bool chat_supported;
+    /* Empty until the bridge reports one. The selectable list is deliberately
+     * not here: it is far larger than the rest of this struct and only one
+     * command needs it, so it is fetched separately. */
+    char model[REMOTE_MODEL_MAX + 1];
+};
+
+/* The model list, copied out under the lock in one go so a console listing
+ * cannot interleave with a bridge update. Too large for the stack on this
+ * target — declare it static at the call site. */
+struct remote_model_view_s {
+    char current[REMOTE_MODEL_MAX + 1];
+    char options[REMOTE_MODEL_OPTIONS_MAX][REMOTE_MODEL_MAX + 1];
+    uint8_t count;
+    bool truncated;
+    bool turn_active;
+};
+
+struct remote_session_s {
+    struct remote_link_s link;
+    struct remote_transport_s* active_transport;
+    char decided_prompt_id[REMOTE_PROMPT_ID_MAX + 1];
+    bool decision_in_flight;
+    uint32_t next_request_number;
+    remote_event_fn on_event;
+    void* event_context;
+    pthread_mutex_t lock;
+    /* Staging buffer for an outbound prompt. Sized to the encoded limit rather
+     * than the text limit, because escaping can expand a prompt several times
+     * over. Serialised by the turn reservation: a second submit is refused
+     * while a turn is in flight. */
+    char prompt_message[REMOTE_MESSAGE_MAX + 1];
+};
+
+/* ── Lifecycle ─────────────────────────────────────────────────────── */
+
+/* Must complete before any other thread can reach the session. */
+void remote_session_init(struct remote_session_s* session, const char* nonce);
+void remote_session_destroy(struct remote_session_s* session);
+void remote_session_set_event_handler(struct remote_session_s* session,
+    remote_event_fn on_event, void* context);
+void remote_session_new_connection(struct remote_session_s* session,
+    const char* nonce);
+void remote_session_set_active_transport(struct remote_session_s* session,
+    struct remote_transport_s* transport);
+void remote_session_link_down(struct remote_session_s* session);
+
+/* ── Inbound (called by the codec) ─────────────────────────────────── */
+
+bool remote_session_snapshot(struct remote_session_s* session,
+    const struct remote_snapshot_s* snapshot, uint32_t now_ms,
+    bool* display_changed);
+bool remote_session_usage_snapshot(struct remote_session_s* session,
+    const struct remote_usage_snapshot_s* snapshot, bool* display_changed);
+/* Session binding is validated inside, so the codec never reads link state
+ * without the lock. */
+/* `title` may be NULL: see remote_link_tool_result. */
+bool remote_session_tool_result(struct remote_session_s* session,
+    const char* connection_nonce, const char* epoch, const char* tool_call_id,
+    const char* status, const char* title);
+bool remote_session_timeout(struct remote_session_s* session, uint32_t now_ms);
+bool remote_session_hello_ack(struct remote_session_s* session,
+    const struct remote_hello_ack_s* ack);
+bool remote_session_prompt_ack(struct remote_session_s* session,
+    const struct remote_prompt_ack_s* ack);
+bool remote_session_agent_output(struct remote_session_s* session,
+    const struct remote_agent_output_s* output, bool* gap_detected);
+bool remote_session_turn_result(struct remote_session_s* session,
+    const struct remote_turn_result_s* result);
+bool remote_session_models(struct remote_session_s* session,
+    const struct remote_models_s* models);
+
+/* ── Outbound ──────────────────────────────────────────────────────── */
+
+/* Sends the connection handshake for the session's current nonce. */
+bool remote_session_send_hello(struct remote_session_s* session);
+
+/* Permission decision. HUMAN INPUT ONLY — reached from NSH commands and, in
+ * future, a GPIO key. This must never be exposed as an LLM-callable tool:
+ * approving a remote agent's tool call is a human act, and a model driving
+ * both sides could approve its own request. */
+bool remote_session_decide(struct remote_session_s* session,
+    enum remote_decision_e decision);
+
+/* Read-only billing refresh. Safe for tools: cannot alter authority state. */
+bool remote_session_query_usage(struct remote_session_s* session);
+
+/* Asks the bridge to switch the remote agent's model for the rest of the
+ * session. Refused while a turn is running. Sending only requests the change:
+ * the bridge validates the name and reports the result in a `models` message,
+ * so a success here means the request left the device, not that it was applied. */
+bool remote_session_select_model(struct remote_session_s* session,
+    const char* model);
+
+/* Submits one chat turn to the remote agent. Safe for tools: rejects locally
+ * while a turn or a permission request is active, so it fails fast instead of
+ * blocking a local agent loop behind a human decision. */
+bool remote_session_submit_prompt(struct remote_session_s* session,
+    const char* text);
+
+/* ── Status ────────────────────────────────────────────────────────── */
+
+void remote_session_status(struct remote_session_s* session,
+    struct remote_status_s* out);
+
+/* Copies the bounded agent transcript. */
+bool remote_session_transcript(struct remote_session_s* session, char* out,
+    size_t out_size);
+
+/* Copies the model list for display. `out` is large; see remote_model_view_s. */
+void remote_session_model_view(struct remote_session_s* session,
+    struct remote_model_view_s* out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/remote/remote_transport.h
+++ b/src/remote/remote_transport.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Pluggable link transport. A transport moves complete JSON messages and knows
+ * nothing about their contents. MQTT is the first one; a newline-framed USB CDC
+ * transport would implement the same single operation. */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct remote_transport_ops_s {
+    bool (*send_json)(void* context, const char* json, size_t length);
+};
+
+struct remote_transport_s {
+    const struct remote_transport_ops_s* ops;
+    void* context;
+};
+
+static inline bool remote_transport_send(struct remote_transport_s* transport,
+    const char* json, size_t length)
+{
+    return transport != NULL && transport->ops != NULL && transport->ops->send_json != NULL && transport->ops->send_json(transport->context, json, length);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/tools/tool_registry.c
+++ b/src/tools/tool_registry.c
@@ -36,6 +36,7 @@
 #include "tools/tool_health.h"
 #include "tools/tool_media.h"
 #include "tools/tool_proxyquickapp.h"
+#include "tools/tool_remote_agent.h"
 #include "tools/tool_shell.h"
 #include "tools/tool_system.h"
 #include "tools/tool_vision.h"
@@ -496,6 +497,29 @@ int tool_registry_init(void)
     REGISTER_TOOL_NO_PARAMS("exit_quickapp",
         "Exit current QuickApp, return to home.",
         tool_exit_quickapp_execute);
+
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+    /* Remote agent control. There is no tool for approving the remote agent's
+     * permission requests: that decision is reserved for a human on this
+     * device. The description says so, so the model reports the wait back to
+     * the user instead of retrying. */
+    REGISTER_TOOL("remote_agent_prompt",
+        "Send one instruction to the remote coding agent on the paired PC and "
+        "wait for its reply. Use for work that needs the PC's files, repo, or "
+        "shell. If the remote agent asks permission to run something, only a "
+        "human at this device can approve it: report that it is pending "
+        "instead of retrying.",
+        TOOL_SCHEMA_BEGIN() TOOL_PARAM_STR("text",
+            "The instruction to send to the remote agent")
+            TOOL_SCHEMA_END_REQUIRED("\"text\""),
+        tool_remote_agent_prompt_execute);
+
+    REGISTER_TOOL_NO_PARAMS("remote_agent_status",
+        "Check the remote coding agent's link state, current activity, "
+        "session billing, and whether it is waiting for a human permission "
+        "decision on this device.",
+        tool_remote_agent_status_execute);
+#endif
 
     build_tools_json_locked();
     syslog(LOG_INFO, "[%s] Tool registry initialized\n", TAG);

--- a/src/tools/tool_remote_agent.c
+++ b/src/tools/tool_remote_agent.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tools/tool_remote_agent.h"
+
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+
+#include "agent_config.h"
+#include "channels/remote_ctrl_channel.h"
+
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static const char* TAG = "tool_remote";
+
+int tool_remote_agent_prompt_execute(const char* input_json, char* output,
+    size_t output_size)
+{
+    cJSON* root;
+    const char* text;
+    int ret;
+
+    root = cJSON_Parse(input_json);
+    if (root == NULL) {
+        snprintf(output, output_size, "Error: invalid JSON input");
+        return ERROR;
+    }
+
+    text = cJSON_GetStringValue(cJSON_GetObjectItem(root, "text"));
+    if (text == NULL || text[0] == '\0') {
+        snprintf(output, output_size, "Error: 'text' is required");
+        cJSON_Delete(root);
+        return ERROR;
+    }
+
+    if (strlen(text) > REMOTE_PROMPT_TEXT_MAX) {
+        snprintf(output, output_size,
+            "Error: prompt exceeds %d bytes; send a shorter instruction",
+            REMOTE_PROMPT_TEXT_MAX);
+        cJSON_Delete(root);
+        return ERROR;
+    }
+
+    syslog(LOG_INFO, "[%s] forwarding prompt (%u bytes)\n", TAG,
+        (unsigned)strlen(text));
+
+    /* The timeout is fixed rather than model-supplied: a large value would let
+     * one tool call stall the whole local agent loop. */
+    ret = remote_ctrl_channel_prompt(text, AGENT_REMOTE_CTRL_TURN_TIMEOUT_MS,
+        output, output_size);
+
+    cJSON_Delete(root);
+    return ret;
+}
+
+int tool_remote_agent_status_execute(const char* input_json, char* output,
+    size_t output_size)
+{
+    struct remote_status_s status;
+    size_t used;
+
+    (void)input_json;
+
+    if (remote_ctrl_channel_status(&status) != OK) {
+        snprintf(output, output_size,
+            "Remote control is not configured on this device.");
+        return OK;
+    }
+
+    used = (size_t)snprintf(output, output_size, "Remote agent: %s",
+        remote_state_name(status.state));
+    if (used >= output_size) {
+        return OK;
+    }
+
+    if (status.summary[0] != '\0') {
+        used += (size_t)snprintf(output + used, output_size - used, " (%s)",
+            status.summary);
+        if (used >= output_size) {
+            return OK;
+        }
+    }
+
+    if (status.billing[0] != '\0') {
+        used += (size_t)snprintf(output + used, output_size - used, "\n%s",
+            status.billing);
+        if (used >= output_size) {
+            return OK;
+        }
+    }
+
+    /* Say plainly that this needs a person: the model has no tool for it and
+     * should report back rather than keep retrying the prompt. */
+    if (status.has_prompt) {
+        used += (size_t)snprintf(output + used, output_size - used,
+            "\nWaiting for a human to approve or deny '%s' on this device"
+            "%s. You cannot answer this yourself; tell the user it is pending.",
+            status.prompt.tool,
+            status.decision_in_flight ? " (a decision was already sent)" : "");
+        if (used >= output_size) {
+            return OK;
+        }
+    }
+
+    if (status.turn_active) {
+        used += (size_t)snprintf(output + used, output_size - used,
+            "\nA remote turn is currently running.");
+        if (used >= output_size) {
+            return OK;
+        }
+    }
+
+    if (!status.chat_supported && status.state != REMOTE_STATE_OFFLINE) {
+        snprintf(output + used, output_size - used,
+            "\nThe remote bridge does not offer chat turns, so prompts cannot "
+            "be sent.");
+    }
+
+    return OK;
+}
+
+#endif /* CONFIG_AI_AGENT_REMOTE_CTRL */

--- a/src/tools/tool_remote_agent.h
+++ b/src/tools/tool_remote_agent.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Tools that let the local agent drive a remote ACP agent.
+ *
+ * There is deliberately no tool for answering the remote agent's permission
+ * requests. Approving a tool call is a human act; a model able to both request
+ * and approve would reduce the permission model to decoration. Those decisions
+ * live in the NSH commands (and later a GPIO key) only.
+ */
+
+#pragma once
+
+#include "agent_compat.h"
+
+#include <stddef.h>
+
+#ifdef CONFIG_AI_AGENT_REMOTE_CTRL
+
+/**
+ * Send one prompt to the remote agent and wait for the turn to finish.
+ * Input: {"text": "..."}
+ * Returns the agent's text, or a description of why nothing could be sent.
+ */
+int tool_remote_agent_prompt_execute(const char* input_json, char* output,
+    size_t output_size);
+
+/**
+ * Report the remote link's state, summary, session billing, and whether a
+ * human permission decision is pending. Read-only.
+ */
+int tool_remote_agent_status_execute(const char* input_json, char* output,
+    size_t output_size);
+
+#endif /* CONFIG_AI_AGENT_REMOTE_CTRL */

--- a/tests/host/run_remote_link_test.sh
+++ b/tests/host/run_remote_link_test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Builds and runs the remote-control protocol test on the development host.
+#
+# The link, codec, and session layers are deliberately free of NuttX and MQTT
+# dependencies, so they compile and run here. The MQTT transport and the channel
+# are not covered: those need a board and a bridge.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+# cJSON lives in the NuttX apps tree next to the package.
+CJSON_DIR="${CJSON_DIR:-$ROOT/../../apps/netutils/cjson/cJSON}"
+if [ ! -f "$CJSON_DIR/cJSON.c" ]; then
+  echo "cJSON source not found at $CJSON_DIR" >&2
+  echo "Set CJSON_DIR to the directory holding cJSON.c" >&2
+  exit 1
+fi
+
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+# cJSON is third-party: compile it without the strict flags used for our code.
+gcc -std=gnu11 -O1 -I "$CJSON_DIR" -c "$CJSON_DIR/cJSON.c" -o "$OUT/cJSON.o"
+
+gcc -std=gnu11 -O1 -g \
+  -Wall -Wextra -Werror \
+  -I "$ROOT/src" -I "$CJSON_DIR" \
+  "$ROOT/src/remote/remote_link.c" \
+  "$ROOT/src/remote/remote_codec.c" \
+  "$ROOT/src/remote/remote_session.c" \
+  "$HERE/test_remote_link.c" \
+  "$OUT/cJSON.o" \
+  -lpthread \
+  -o "$OUT/test_remote_link"
+
+"$OUT/test_remote_link"

--- a/tests/host/test_remote_link.c
+++ b/tests/host/test_remote_link.c
@@ -1,0 +1,718 @@
+/*
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Host test for the remote-control protocol core.
+ *
+ * The link, codec, and session layers have no NuttX or MQTT dependency, so the
+ * authority rules can be checked on a development machine. Build and run:
+ *
+ *   tests/host/run_remote_link_test.sh
+ *
+ * This is protocol-level coverage only. It says nothing about MQTT transport,
+ * board bring-up, or a real bridge.
+ */
+
+#include "remote/remote_codec.h"
+#include "remote/remote_session.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+/* ── Capture transport ─────────────────────────────────────────────── */
+
+struct capture_s {
+    unsigned int sends;
+    bool fail_next;
+    char message[REMOTE_MESSAGE_MAX + 1];
+};
+
+static bool capture_send(void* context, const char* json, size_t length)
+{
+    struct capture_s* capture = context;
+
+    assert(length <= REMOTE_MESSAGE_MAX);
+
+    if (capture->fail_next) {
+        capture->fail_next = false;
+        return false;
+    }
+
+    memcpy(capture->message, json, length);
+    capture->message[length] = '\0';
+    capture->sends++;
+    return true;
+}
+
+static const struct remote_transport_ops_s g_capture_ops = {
+    .send_json = capture_send,
+};
+
+/* ── Event capture ─────────────────────────────────────────────────── */
+
+struct events_s {
+    unsigned int state;
+    unsigned int output;
+    unsigned int gaps;
+    unsigned int transcripts;
+    unsigned int turn_results;
+    unsigned int rejected;
+    unsigned int billing;
+    unsigned int models;
+    /* The reply as the handler received it, plus the order it arrived in
+     * relative to the turn result: a reply printed after "turn completed" would
+     * read backwards. */
+    char transcript[REMOTE_TRANSCRIPT_MAX + 1];
+    bool transcript_before_result;
+};
+
+static void on_event(void* context, enum remote_event_e event, const char* text)
+{
+    struct events_s* events = context;
+
+    switch (event) {
+    case REMOTE_EVENT_STATE:
+        events->state++;
+        break;
+    case REMOTE_EVENT_AGENT_OUTPUT:
+        events->output++;
+        break;
+    case REMOTE_EVENT_OUTPUT_GAP:
+        events->gaps++;
+        break;
+    case REMOTE_EVENT_TURN_TRANSCRIPT:
+        events->transcripts++;
+        if (text != NULL) {
+            snprintf(events->transcript, sizeof(events->transcript), "%s", text);
+        }
+        if (events->turn_results == 0) {
+            events->transcript_before_result = true;
+        }
+        break;
+    case REMOTE_EVENT_TURN_RESULT:
+        events->turn_results++;
+        break;
+    case REMOTE_EVENT_PROMPT_REJECTED:
+        events->rejected++;
+        break;
+    case REMOTE_EVENT_BILLING:
+        events->billing++;
+        break;
+    case REMOTE_EVENT_MODEL:
+        events->models++;
+        break;
+    default:
+        break;
+    }
+}
+
+/* ── Authority, permission latch, and billing ──────────────────────── */
+
+static void test_authority_and_permission(void)
+{
+    struct remote_session_s session;
+    struct capture_s capture = { 0 };
+    struct events_s events = { 0 };
+    struct remote_transport_s transport = {
+        .ops = &g_capture_ops,
+        .context = &capture,
+    };
+    struct remote_prompt_s prompt = {
+        .id = "prompt-1",
+        .tool = "bash_delete",
+        .hint = "rm /tmp/probe",
+        .can_once = true,
+        .can_deny = true,
+    };
+    struct remote_snapshot_s snapshot = {
+        .connection_nonce = "nonce",
+        .epoch = "epoch",
+        .seq = 1,
+        .running = 0,
+        .summary = "approval required",
+        .prompt = &prompt,
+    };
+    struct remote_usage_snapshot_s usage = {
+        .connection_nonce = "nonce",
+        .epoch = "epoch",
+        .seq = 1,
+        .has_charge = true,
+        .charge_kind = REMOTE_CHARGE_CREDIT,
+        .charge_amount = 0.375,
+        .charge_unit = "credits",
+        .has_tokens = true,
+        .input_tokens = 11,
+        .output_tokens = 3,
+        .total_tokens = 14,
+        .has_context = true,
+        .context_unit = REMOTE_CONTEXT_TOKEN,
+        .context_used = 17,
+        .context_limit = 1000,
+    };
+    struct remote_status_s status;
+    char overlong_summary[REMOTE_SUMMARY_MAX + 2];
+    bool changed;
+
+    remote_session_init(&session, "nonce");
+    remote_session_set_event_handler(&session, on_event, &events);
+    remote_session_set_active_transport(&session, &transport);
+
+    /* First snapshot locks the epoch and raises the attention state. */
+    assert(remote_session_snapshot(&session, &snapshot, 100, &changed));
+    assert(changed);
+    remote_session_status(&session, &status);
+    assert(status.state == REMOTE_STATE_ATTENTION);
+    assert(status.has_prompt);
+    assert(events.state == 1);
+
+    /* Usage telemetry is independent of authority and must not disturb it. */
+    assert(remote_session_usage_snapshot(&session, &usage, &changed));
+    assert(changed);
+    assert(events.billing == 1);
+    remote_session_status(&session, &status);
+    assert(status.state == REMOTE_STATE_ATTENTION);
+    assert(status.has_prompt);
+    assert(strcmp(status.billing, "Billing: 0.375 credits / 14 tokens") == 0);
+
+    /* A repeated usage sequence is stale and rejected. */
+    assert(!remote_session_usage_snapshot(&session, &usage, &changed));
+
+    /* A QoS 0 gap may skip a sequence; a newer one still applies. Either
+     * billing slot may be absent and is then rendered empty, never zero. */
+    usage.seq = 3;
+    usage.has_charge = false;
+    usage.has_tokens = true;
+    usage.total_tokens = 25;
+    assert(remote_session_usage_snapshot(&session, &usage, &changed));
+    remote_session_status(&session, &status);
+    assert(strcmp(status.billing, "Billing:  / 25 tokens") == 0);
+
+    usage.seq = 2;
+    assert(!remote_session_usage_snapshot(&session, &usage, &changed));
+
+    usage.seq = 4;
+    usage.has_charge = true;
+    usage.charge_amount = 0.5;
+    usage.has_tokens = false;
+    assert(remote_session_usage_snapshot(&session, &usage, &changed));
+    remote_session_status(&session, &status);
+    assert(strcmp(status.billing, "Billing: 0.5 credits / ") == 0);
+
+    /* Read-only query is allowed while a permission is pending. */
+    assert(remote_session_query_usage(&session));
+    assert(capture.sends == 1);
+    assert(strstr(capture.message, "\"cmd\":\"usage_query\"") != NULL);
+    assert(strstr(capture.message, "\"connection_nonce\":\"nonce\"") != NULL);
+
+    /* One decision per prompt: the second is refused locally. */
+    assert(remote_session_decide(&session, REMOTE_DECISION_DENY));
+    assert(capture.sends == 2);
+    assert(strstr(capture.message, "\"decision\":\"deny\"") != NULL);
+    assert(strstr(capture.message, "\"cmd\":\"permission\"") != NULL);
+    assert(!remote_session_decide(&session, REMOTE_DECISION_DENY));
+    assert(!remote_session_decide(&session, REMOTE_DECISION_ONCE));
+    assert(capture.sends == 2);
+
+    /* A repeat of the same prompt keeps the latch closed. */
+    snapshot.seq = 2;
+    assert(remote_session_snapshot(&session, &snapshot, 101, &changed));
+    assert(!changed);
+    remote_session_status(&session, &status);
+    assert(status.decision_in_flight);
+
+    /* An unrelated tool result is not authority to clear a pending prompt. */
+    assert(!remote_session_tool_result(&session, "nonce", "epoch",
+        "unrelated-tool", "completed", NULL));
+    remote_session_status(&session, &status);
+    assert(status.has_prompt);
+    assert(status.decision_in_flight);
+
+    /* An oversized summary and a wrong sequence are both rejected. */
+    memset(overlong_summary, 'x', sizeof(overlong_summary) - 1);
+    overlong_summary[sizeof(overlong_summary) - 1] = '\0';
+    snapshot.seq = 3;
+    snapshot.summary = overlong_summary;
+    assert(!remote_session_snapshot(&session, &snapshot, 102, &changed));
+
+    snapshot.summary = "approval required";
+    snapshot.seq = 4; /* expected 3 */
+    assert(!remote_session_snapshot(&session, &snapshot, 102, &changed));
+
+    /* Liveness is independent of the socket: no snapshots means Offline. */
+    assert(remote_session_timeout(&session, 30102));
+    remote_session_status(&session, &status);
+    assert(status.state == REMOTE_STATE_OFFLINE);
+    assert(!status.has_prompt);
+    assert(strcmp(status.billing, "Billing:  / ") == 0);
+
+    /* With no prompt pending, a tool result may report a result state. With no
+     * title, the tool-call id is the fallback label. */
+    assert(remote_session_tool_result(&session, "nonce", "", "tool-1",
+        "completed", NULL));
+    remote_session_status(&session, &status);
+    assert(status.state == REMOTE_STATE_RESULT);
+    assert(strcmp(status.summary, "tool 'tool-1' completed") == 0);
+    assert(!remote_session_tool_result(&session, "nonce", "", "tool-1",
+        "pending", NULL));
+
+    /* A title replaces the unreadable id, and an empty one falls back to it. */
+    assert(remote_session_tool_result(&session, "nonce", "", "tooluse_9xQz",
+        "completed", "Delete /tmp/1.txt"));
+    remote_session_status(&session, &status);
+    assert(strcmp(status.summary, "tool 'Delete /tmp/1.txt' completed") == 0);
+
+    assert(remote_session_tool_result(&session, "nonce", "", "tooluse_9xQz",
+        "failed", ""));
+    remote_session_status(&session, &status);
+    assert(strcmp(status.summary, "tool 'tooluse_9xQz' failed") == 0);
+
+    /* A control byte in a title would split the one-line status into two, so it
+     * is flattened to a space rather than passed through. */
+    assert(remote_session_tool_result(&session, "nonce", "", "tool-2",
+        "completed", "line\nbreak\ttab"));
+    remote_session_status(&session, &status);
+    assert(strcmp(status.summary, "tool 'line break tab' completed") == 0);
+
+    remote_session_destroy(&session);
+    printf("  authority, permission latch, billing: ok\n");
+}
+
+/* ── Chat turns ────────────────────────────────────────────────────── */
+
+static void test_chat_turns(void)
+{
+    struct remote_session_s session;
+    struct capture_s capture = { 0 };
+    struct events_s events = { 0 };
+    struct remote_transport_s transport = {
+        .ops = &g_capture_ops,
+        .context = &capture,
+    };
+    struct remote_hello_ack_s hello_ack = {
+        .connection_nonce = "chat-nonce",
+        .epoch = "chat-epoch",
+        .chat_turns = true,
+    };
+    struct remote_snapshot_s snapshot = {
+        .connection_nonce = "chat-nonce",
+        .epoch = "chat-epoch",
+        .seq = 1,
+        .running = 0,
+        .summary = "Agent ready",
+        .prompt = NULL,
+    };
+    struct remote_prompt_ack_s prompt_ack = {
+        .connection_nonce = "chat-nonce",
+        .epoch = "chat-epoch",
+        .request_id = "r-chat-nonce-00000001",
+        .turn_id = "turn-1",
+        .accepted = true,
+    };
+    struct remote_agent_output_s output = {
+        .connection_nonce = "chat-nonce",
+        .epoch = "chat-epoch",
+        .request_id = "r-chat-nonce-00000001",
+        .turn_id = "turn-1",
+        .seq = 1,
+        .text = "first answer\n",
+    };
+    struct remote_turn_result_s turn_result = {
+        .connection_nonce = "chat-nonce",
+        .epoch = "chat-epoch",
+        .request_id = "r-chat-nonce-00000001",
+        .turn_id = "turn-1",
+        .status = "completed",
+    };
+    struct remote_status_s status;
+    char transcript[REMOTE_TRANSCRIPT_MAX + 1];
+    bool changed;
+    bool gap;
+
+    remote_session_init(&session, "chat-nonce");
+    remote_session_set_event_handler(&session, on_event, &events);
+    remote_session_set_active_transport(&session, &transport);
+
+    /* No prompt may be sent before the bridge advertises chat turns. */
+    assert(!remote_session_submit_prompt(&session, "too early"));
+
+    assert(remote_session_hello_ack(&session, &hello_ack));
+    assert(remote_session_snapshot(&session, &snapshot, 1, &changed));
+
+    /* cJSON owns the escaping, so quotes in the prompt cannot break the wire
+     * form. */
+    assert(remote_session_submit_prompt(&session, "inspect \"this\""));
+    assert(capture.sends == 1);
+    assert(strstr(capture.message, "\"cmd\":\"prompt_submit\"") != NULL);
+    assert(strstr(capture.message, "inspect \\\"this\\\"") != NULL);
+    assert(strstr(capture.message, "\"request_id\":\"r-chat-nonce-00000001\"") != NULL);
+
+    /* The turn slot is reserved, so a second submit is refused. */
+    assert(!remote_session_submit_prompt(&session, "second"));
+    assert(capture.sends == 1);
+
+    assert(remote_session_prompt_ack(&session, &prompt_ack));
+    assert(remote_session_agent_output(&session, &output, &gap));
+    assert(!gap);
+    assert(events.output == 1);
+    assert(remote_session_transcript(&session, transcript, sizeof(transcript)));
+    assert(strcmp(transcript, "first answer\n") == 0);
+
+    /* A skipped output sequence is noted but does not change authority. */
+    output.seq = 3;
+    output.text = "third answer";
+    assert(remote_session_agent_output(&session, &output, &gap));
+    assert(gap);
+    assert(events.gaps == 1);
+
+    /* Replays and wrong turn ids are dropped. */
+    assert(!remote_session_agent_output(&session, &output, &gap));
+    output.seq = 4;
+    output.turn_id = "wrong-turn";
+    assert(!remote_session_agent_output(&session, &output, &gap));
+
+    assert(remote_session_turn_result(&session, &turn_result));
+    assert(events.turn_results == 1);
+    remote_session_status(&session, &status);
+    assert(!status.turn_active);
+    assert(remote_session_transcript(&session, transcript, sizeof(transcript)));
+    assert(strstr(transcript, "third answer") != NULL);
+
+    /* The whole reply is handed over once, as one piece, before the turn result.
+     * This is what makes a reply readable: the chunks that arrived separately are
+     * never presented separately. */
+    assert(events.transcripts == 1);
+    assert(events.transcript_before_result);
+    assert(strcmp(events.transcript, "first answer\nthird answer") == 0);
+    assert(events.output == 2);
+
+    /* A turn that produced no text emits no transcript event, so nothing prints
+     * an empty reply. Submitting clears the previous transcript, which is why the
+     * check has to happen on a fresh turn rather than by inspecting this one. */
+    prompt_ack.request_id = "r-chat-nonce-00000002";
+    prompt_ack.turn_id = "turn-2";
+    turn_result.request_id = "r-chat-nonce-00000002";
+    turn_result.turn_id = "turn-2";
+    assert(remote_session_submit_prompt(&session, "a turn that only runs tools"));
+    assert(remote_session_prompt_ack(&session, &prompt_ack));
+    assert(remote_session_turn_result(&session, &turn_result));
+    assert(events.transcripts == 1);
+    assert(events.turn_results == 2);
+
+    remote_session_destroy(&session);
+    printf("  chat turns, output sequencing, escaping: ok\n");
+}
+
+/* ── Send failure rolls the turn back ──────────────────────────────── */
+
+static void test_send_failure_releases_turn(void)
+{
+    struct remote_session_s session;
+    struct capture_s capture = { 0 };
+    struct remote_transport_s transport = {
+        .ops = &g_capture_ops,
+        .context = &capture,
+    };
+    struct remote_hello_ack_s hello_ack = {
+        .connection_nonce = "n2",
+        .epoch = "e2",
+        .chat_turns = true,
+    };
+    struct remote_snapshot_s snapshot = {
+        .connection_nonce = "n2",
+        .epoch = "e2",
+        .seq = 1,
+        .running = 0,
+        .summary = "ready",
+        .prompt = NULL,
+    };
+    struct remote_status_s status;
+    bool changed;
+
+    remote_session_init(&session, "n2");
+    remote_session_set_active_transport(&session, &transport);
+    assert(remote_session_hello_ack(&session, &hello_ack));
+    assert(remote_session_snapshot(&session, &snapshot, 1, &changed));
+
+    /* A publish that fails must not leave the turn slot reserved, or the
+     * device could never send another prompt on this connection. */
+    capture.fail_next = true;
+    assert(!remote_session_submit_prompt(&session, "will not send"));
+    remote_session_status(&session, &status);
+    assert(!status.turn_active);
+
+    assert(remote_session_submit_prompt(&session, "retry"));
+    remote_session_status(&session, &status);
+    assert(status.turn_active);
+
+    remote_session_destroy(&session);
+    printf("  send failure releases the turn slot: ok\n");
+}
+
+/* ── Inbound wire decoding ─────────────────────────────────────────── */
+
+static void test_codec_receive(void)
+{
+    struct remote_session_s session;
+    struct capture_s capture = { 0 };
+    struct events_s events = { 0 };
+    struct remote_transport_s transport = {
+        .ops = &g_capture_ops,
+        .context = &capture,
+    };
+    struct remote_status_s status;
+    char oversized[REMOTE_MESSAGE_MAX + 64];
+    const char* snapshot_json
+        = "{\"v\":1,\"type\":\"snapshot\",\"connection_nonce\":\"wire-nonce\","
+          "\"epoch\":\"wire-epoch\",\"seq\":1,\"running\":0,"
+          "\"msg\":\"waiting for you\",\"prompt\":{\"id\":\"p\\\"quoted\","
+          "\"tool\":\"bash\",\"hint\":\"rm -rf /tmp/x\",\"canOnce\":true,"
+          "\"canDeny\":true}}";
+
+    remote_session_init(&session, "wire-nonce");
+    remote_session_set_event_handler(&session, on_event, &events);
+    remote_session_set_active_transport(&session, &transport);
+
+    remote_codec_receive(&session, snapshot_json, strlen(snapshot_json), 500);
+    remote_session_status(&session, &status);
+    assert(status.state == REMOTE_STATE_ATTENTION);
+    assert(status.has_prompt);
+    assert(strcmp(status.summary, "waiting for you") == 0);
+    /* An embedded quote survives decode and is re-escaped on the way out. */
+    assert(strcmp(status.prompt.id, "p\"quoted") == 0);
+    assert(remote_session_decide(&session, REMOTE_DECISION_ONCE));
+    assert(strstr(capture.message, "p\\\"quoted") != NULL);
+
+    /* A message from another session is ignored. */
+    {
+        const char* foreign
+            = "{\"v\":1,\"type\":\"snapshot\",\"connection_nonce\":\"other\","
+              "\"epoch\":\"wire-epoch\",\"seq\":2,\"running\":1,"
+              "\"msg\":\"not mine\",\"prompt\":null}";
+
+        remote_codec_receive(&session, foreign, strlen(foreign), 600);
+        remote_session_status(&session, &status);
+        assert(strcmp(status.summary, "waiting for you") == 0);
+    }
+
+    /* Malformed, truncated, and trailing-garbage payloads are all dropped. */
+    {
+        const char* bad[] = {
+            "{",
+            "not json at all",
+            "{\"v\":2,\"type\":\"snapshot\"}",
+            "{\"v\":1,\"type\":\"snapshot\"} trailing",
+            "[]",
+        };
+        size_t index;
+
+        for (index = 0; index < sizeof(bad) / sizeof(bad[0]); index++) {
+            remote_codec_receive(&session, bad[index], strlen(bad[index]), 700);
+        }
+        remote_session_status(&session, &status);
+        assert(strcmp(status.summary, "waiting for you") == 0);
+    }
+
+    /* An escaped NUL could truncate a nonce into a prefix match, so its only
+     * legal wire form is refused before parsing. */
+    {
+        const char* escaped_nul
+            = "{\"v\":1,\"type\":\"snapshot\",\"connection_nonce\":"
+              "\"wire-nonce\\u0000ignored\",\"epoch\":\"wire-epoch\","
+              "\"seq\":2,\"running\":1,\"msg\":\"nul\",\"prompt\":null}";
+
+        remote_codec_receive(&session, escaped_nul, strlen(escaped_nul), 800);
+        remote_session_status(&session, &status);
+        assert(strcmp(status.summary, "waiting for you") == 0);
+    }
+
+    /* Anything beyond the link cap is dropped whole rather than parsed. */
+    memset(oversized, 'x', sizeof(oversized) - 1);
+    oversized[sizeof(oversized) - 1] = '\0';
+    remote_codec_receive(&session, oversized, strlen(oversized), 900);
+    remote_session_status(&session, &status);
+    assert(strcmp(status.summary, "waiting for you") == 0);
+
+    remote_session_destroy(&session);
+    printf("  inbound decoding, session binding, hostile payloads: ok\n");
+}
+
+/* ── Offline refuses every outbound operation ──────────────────────── */
+
+static void test_offline_refuses_output(void)
+{
+    struct remote_session_s session;
+    struct capture_s capture = { 0 };
+    struct remote_transport_s transport = {
+        .ops = &g_capture_ops,
+        .context = &capture,
+    };
+
+    remote_session_init(&session, "off-nonce");
+    remote_session_set_active_transport(&session, &transport);
+
+    assert(!remote_session_submit_prompt(&session, "hello"));
+    assert(!remote_session_query_usage(&session));
+    assert(!remote_session_decide(&session, REMOTE_DECISION_ONCE));
+
+    /* Only the handshake may leave before any snapshot has arrived. */
+    assert(remote_session_send_hello(&session));
+    assert(capture.sends == 1);
+    assert(strstr(capture.message, "\"cmd\":\"hello\"") != NULL);
+    assert(strstr(capture.message, "\"connection_nonce\":\"off-nonce\"") != NULL);
+
+    remote_session_destroy(&session);
+    printf("  offline refuses outbound except hello: ok\n");
+}
+
+/* ── Model reporting and selection ─────────────────────────────────── */
+
+static void test_model_selection(void)
+{
+    struct remote_session_s session;
+    struct capture_s capture = { 0 };
+    struct events_s events = { 0 };
+    struct remote_transport_s transport = {
+        .ops = &g_capture_ops,
+        .context = &capture,
+    };
+    struct remote_hello_ack_s hello_ack = {
+        .connection_nonce = "m-nonce",
+        .epoch = "m-epoch",
+        .chat_turns = true,
+    };
+    struct remote_snapshot_s snapshot = {
+        .connection_nonce = "m-nonce",
+        .epoch = "m-epoch",
+        .seq = 1,
+        .running = 0,
+        .summary = "Agent ready",
+        .prompt = NULL,
+    };
+    /* Deliberately static, as on the device: the option table makes this far too
+     * large to want on a small stack. */
+    static struct remote_model_view_s view;
+    struct remote_status_s status;
+    char crowded[REMOTE_MESSAGE_MAX];
+    const char* early
+        = "{\"v\":1,\"type\":\"models\",\"connection_nonce\":\"m-nonce\","
+          "\"epoch\":\"m-epoch\",\"current\":\"kiro/a\",\"options\":[\"kiro/a\"]}";
+    const char* offered
+        = "{\"v\":1,\"type\":\"models\",\"connection_nonce\":\"m-nonce\","
+          "\"epoch\":\"m-epoch\",\"current\":\"kiro/sonnet\","
+          "\"options\":[\"kiro/sonnet\",\"kiro/haiku\",\"mify/zhipuai/glm\"],"
+          "\"truncated\":false}";
+    bool changed;
+    size_t used;
+    int i;
+
+    remote_session_init(&session, "m-nonce");
+    remote_session_set_event_handler(&session, on_event, &events);
+    remote_session_set_active_transport(&session, &transport);
+
+    /* Nothing is known before the bridge reports, and nothing may be selected
+     * while offline. */
+    remote_session_model_view(&session, &view);
+    assert(view.current[0] == '\0');
+    assert(view.count == 0);
+    assert(!remote_session_select_model(&session, "kiro/haiku"));
+
+    /* Models arriving before the first snapshot are dropped: the session epoch
+     * is not locked yet, so nothing epoch-stamped can be trusted. This is the
+     * ordering the bridge has to respect. */
+    remote_codec_receive(&session, early, strlen(early), 100);
+    remote_session_model_view(&session, &view);
+    assert(view.current[0] == '\0');
+    assert(events.models == 0);
+
+    assert(remote_session_hello_ack(&session, &hello_ack));
+    assert(remote_session_snapshot(&session, &snapshot, 100, &changed));
+
+    remote_codec_receive(&session, offered, strlen(offered), 200);
+    remote_session_model_view(&session, &view);
+    assert(strcmp(view.current, "kiro/sonnet") == 0);
+    assert(view.count == 3);
+    assert(!view.truncated);
+    assert(strcmp(view.options[2], "mify/zhipuai/glm") == 0);
+    assert(events.models == 1);
+
+    /* The model also shows up in the status a console prints. */
+    remote_session_status(&session, &status);
+    assert(strcmp(status.model, "kiro/sonnet") == 0);
+
+    /* The bridge repeats this message on every handshake. An unchanged model
+     * must not announce itself again, or a quiet link turns into a stream. */
+    remote_codec_receive(&session, offered, strlen(offered), 300);
+    assert(events.models == 1);
+
+    /* Selecting sends a request; it does not decide. The device only learns the
+     * model in use from a later `models` message. */
+    capture.sends = 0;
+    assert(remote_session_select_model(&session, "mify/zhipuai/glm"));
+    assert(capture.sends == 1);
+    assert(strstr(capture.message, "\"cmd\":\"model_select\"") != NULL);
+    assert(strstr(capture.message, "\"model\":\"mify/zhipuai/glm\"") != NULL);
+    remote_session_status(&session, &status);
+    assert(strcmp(status.model, "kiro/sonnet") == 0);
+
+    /* A turn owns the model that started it, so a switch is refused until the
+     * turn ends rather than changing models mid-reply. */
+    assert(remote_session_submit_prompt(&session, "work on this"));
+    capture.sends = 0;
+    assert(!remote_session_select_model(&session, "kiro/haiku"));
+    assert(capture.sends == 0);
+    remote_session_model_view(&session, &view);
+    assert(view.turn_active);
+
+    /* More names than the device holds: the extras are dropped and the list is
+     * reported as partial, so the console never implies it showed everything. */
+    used = (size_t)snprintf(crowded, sizeof(crowded),
+        "{\"v\":1,\"type\":\"models\",\"connection_nonce\":\"m-nonce\","
+        "\"epoch\":\"m-epoch\",\"current\":\"kiro/sonnet\",\"options\":[");
+    for (i = 0; i < REMOTE_MODEL_OPTIONS_MAX + 8; i++) {
+        used += (size_t)snprintf(crowded + used, sizeof(crowded) - used,
+            "%s\"kiro/m%d\"", i > 0 ? "," : "", i);
+    }
+    snprintf(crowded + used, sizeof(crowded) - used, "]}");
+    remote_codec_receive(&session, crowded, strlen(crowded), 400);
+    remote_session_model_view(&session, &view);
+    assert(view.count == REMOTE_MODEL_OPTIONS_MAX);
+    assert(view.truncated);
+
+    /* A losing connection forgets the model rather than keeping a stale one: the
+     * next bridge may be a different session entirely. */
+    remote_session_link_down(&session);
+    remote_session_model_view(&session, &view);
+    assert(view.current[0] == '\0');
+    assert(view.count == 0);
+    remote_session_status(&session, &status);
+    assert(status.model[0] == '\0');
+
+    remote_session_destroy(&session);
+    printf("  model reporting, selection, truncation: ok\n");
+}
+
+int main(void)
+{
+    printf("remote-control protocol core:\n");
+    test_authority_and_permission();
+    test_chat_turns();
+    test_send_failure_releases_turn();
+    test_codec_receive();
+    test_offline_refuses_output();
+    test_model_selection();
+    printf("all remote-control protocol tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Lets this device operate a coding agent (mimocode or kiro-cli) running on a PC, reached through a bridge that speaks MQTT to the device. ACP assumes a stable stdio pipe, unbounded messages and blocking two-way calls, none of which hold over WiFi on a constrained device, so the link layer here is the adaptation: bounded messages, a nonce/epoch authority model, and an explicit table of pending inbound requests.

- src/remote: protocol state machine, JSON codec, session, MQTT transport
- src/channels/remote_ctrl_channel: wiring, event handling, blocking turn wait
- console commands rask, rstat, rreply, rmodel, rusage, ronce, rdeny
- two LLM-callable tools for prompting and status

Permission decisions are deliberately absent from the tool registry: a model that could both request and approve its own tool call would leave the permission model decorative. Only ronce/rdeny answer them.

The reply is accumulated and printed once when the turn ends. Streaming it as it arrived was unreadable, because the bridge flushes every 40ms and the bounded status field truncates each slice to 128 bytes.

tests/host covers the protocol in six groups and needs no broker, bridge or emulator. Kconfig default n; built and run on goldfish-arm64-v8a-ap only.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
