### PR TITLE
ai_agent: SRAM-tight HMI mode and VelaGuard tool allow-list for STM32H750B-DK

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -42,6 +42,14 @@ config EXAMPLES_AI_AGENT_VELA_STACKSIZE
 	int "Agent main stack size"
 	default 32768
 
+config EXAMPLES_AI_AGENT_VELA_TIME_OFFSET_SEC
+	int "Seconds added to the system clock for local time (CST=28800)"
+	default 28800
+	---help---
+		get_current_time and the system prompt header compute local
+		time as clock + this offset. Set 0 when the system clock already
+		runs local wall time (e.g. VelaGuard HMI syncs Beijing time).
+
 config EXAMPLES_AI_AGENT_VELA_DATA_DIR
 	string "Persistent data directory"
 	default "/data/ai_agent"

--- a/include/agent_config.h
+++ b/include/agent_config.h
@@ -407,3 +407,25 @@
 #define AGENT_SHELL_SECURITY AGENT_SHELL_SECURITY_ALLOWLIST /* default \
                                                                    */
 #endif
+
+/* ── VelaGuard HMI (SRAM-tight) ──────────────────────────────── */
+#ifdef CONFIG_VG_HMI
+#undef AGENT_AI_AGENT_STACK
+#define AGENT_AI_AGENT_STACK (16 * 1024)
+#undef AGENT_CLI_STACK
+#define AGENT_CLI_STACK (12 * 1024)
+#undef AGENT_CRON_STACK
+#define AGENT_CRON_STACK (4 * 1024)
+#define AGENT_VG_HMI_SKIP_WS 1
+#define AGENT_VG_HMI_LAZY_LOOP 1
+#define AGENT_MEM_RESERVE_BYTES (8 * 1024)
+#undef AGENT_CONTEXT_BUF_SIZE
+#define AGENT_CONTEXT_BUF_SIZE (4 * 1024)
+#undef AGENT_LLM_STREAM_BUF_SIZE
+#define AGENT_LLM_STREAM_BUF_SIZE (4 * 1024)
+#undef AGENT_OUTBOUND_STACK
+#define AGENT_OUTBOUND_STACK (12 * 1024)
+#define AGENT_NET_WATCH_STACK (28 * 1024)
+#else
+#define AGENT_NET_WATCH_STACK AGENT_OUTBOUND_STACK
+#endif

--- a/include/agent_config.h
+++ b/include/agent_config.h
@@ -116,7 +116,7 @@
  * a timeout and replies with a user-friendly error message.
  * The socket-level SO_RCVTIMEO (AGENT_LLM_SOCKET_TIMEOUT_SEC)
  * acts as the hard backstop that actually unblocks the read. */
-#define AGENT_LLM_TIMEOUT_SEC 60
+#define AGENT_LLM_TIMEOUT_SEC 120
 
 /* Socket-level read timeout applied via SO_RCVTIMEO in vela_tls.
  * Must be >= AGENT_LLM_TIMEOUT_SEC to allow the agent-level

--- a/include/agent_config.h
+++ b/include/agent_config.h
@@ -101,6 +101,15 @@
 #define AGENT_FEISHU_POLL_PRIO 50
 #define AGENT_FEISHU_MAX_MSG_LEN 4000 /* Feishu text message limit */
 
+/* ── Time ───────────────────────────────────────────────────── */
+/* Offset applied by get_current_time / context header on top of the
+ * system clock. 0 when the clock already runs local wall time. */
+#ifdef CONFIG_EXAMPLES_AI_AGENT_VELA_TIME_OFFSET_SEC
+#define AGENT_TIME_OFFSET_SEC CONFIG_EXAMPLES_AI_AGENT_VELA_TIME_OFFSET_SEC
+#else
+#define AGENT_TIME_OFFSET_SEC (8 * 3600)
+#endif
+
 /* ── Agent Loop ─────────────────────────────────────────────── */
 #define AGENT_AI_AGENT_STACK (32 * 1024)
 #define AGENT_AI_AGENT_PRIO 60
@@ -410,8 +419,14 @@
 
 /* ── VelaGuard HMI (SRAM-tight) ──────────────────────────────── */
 #ifdef CONFIG_VG_HMI
+/* The agent loop thread runs the whole ReAct round on one stack:
+ * mbedTLS handshake (~14KB), 15KB tools-JSON request build/parse, and
+ * tool dispatch. 16KB overflowed into heap-adjacent memory and
+ * corrupted free-node metadata (HARDFAULT in mallinfo/mm_foreach on
+ * VelaGuard H750B-DK, deterministic with any tool-calling round).
+ * 32KB matches the non-HMI default; SRAM budget on H750B-DK allows it. */
 #undef AGENT_AI_AGENT_STACK
-#define AGENT_AI_AGENT_STACK (16 * 1024)
+#define AGENT_AI_AGENT_STACK (32 * 1024)
 #undef AGENT_CLI_STACK
 #define AGENT_CLI_STACK (12 * 1024)
 #undef AGENT_CRON_STACK

--- a/src/agent_main.c
+++ b/src/agent_main.c
@@ -86,6 +86,35 @@
 
 static const char* TAG = "agent";
 
+/* Daemon autostart (--daemon): cron/heartbeat/network, no stdin CLI. */
+static volatile bool g_daemon_running = false;
+
+static bool argv_has_flag(int argc, char* argv[], const char* flag)
+{
+    for (int i = 1; i < argc; i++) {
+        if (argv[i] != NULL && strcmp(argv[i], flag) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* NuttX boards without RTC boot at epoch; TLS may jump the clock mid-call.
+ * Set a sane wall clock once at agent start, before any HTTPS traffic. */
+static void ensure_wall_clock_for_tls(void)
+{
+    time_t now = time(NULL);
+
+    if (now >= 1704067200) { /* Jan 1 2024 UTC */
+        return;
+    }
+
+    struct timespec ts = { .tv_sec = 1772275200, .tv_nsec = 0 }; /* 2026-02-28 */
+    clock_settime(CLOCK_REALTIME, &ts);
+    syslog(LOG_WARNING, "[%s] Wall clock was stale (%ld), set for TLS\n",
+        TAG, (long)now);
+}
+
 /* ── stdout mutex — shared with nsh_commands.c ──────────────── */
 /* Prevents concurrent printf from outbound_dispatch_task and cli_thread
  * which causes adbd shell_service_uv assert (wait_ack != 0). */
@@ -466,8 +495,25 @@ static inline long boot_ms(struct timespec* t0)
 
 int ai_agent_main(int argc, char* argv[])
 {
-    (void)argc;
-    (void)argv;
+    const bool daemon_mode = argv_has_flag(argc, argv, "--daemon");
+    const bool skip_cli = daemon_mode;
+
+    if (daemon_mode) {
+        if (g_daemon_running) {
+            return 0;
+        }
+    } else if (g_daemon_running) {
+        /* Background daemon is up; attach an interactive CLI on NSH stdin. */
+        syslog(LOG_INFO, "[%s] Attaching CLI to daemon agent\n", TAG);
+        nsh_commands_set_detach_quit(true);
+        nsh_commands_run_interactive();
+        nsh_commands_set_detach_quit(false);
+        return 0;
+    }
+
+    if (daemon_mode) {
+        g_daemon_running = true;
+    }
 
     g_shutdown_requested = false;
 
@@ -485,6 +531,7 @@ int ai_agent_main(int argc, char* argv[])
 #ifdef CONFIG_LIBC_LOCALTIME
     tzset();
 #endif
+    ensure_wall_clock_for_tls();
     BOOT_LOG(&t0, "P0", "timezone set");
 
     /* ── Phase 0: Storage Bootstrapping (Auto-mount & Mkdir) ── */
@@ -518,8 +565,12 @@ int ai_agent_main(int argc, char* argv[])
 
         rc = message_bus_init();
         BOOT_LOG_RC(&t0, "P1", "message_bus_init", rc);
-        if (rc != OK)
+        if (rc != OK) {
+            if (daemon_mode) {
+                g_daemon_running = false;
+            }
             return -1;
+        }
 
         rc = memory_store_init();
         BOOT_LOG_RC(&t0, "P1", "memory_store_init", rc);
@@ -618,6 +669,9 @@ int ai_agent_main(int argc, char* argv[])
             AGENT_OUTBOUND_PRIO)
         != OK) {
         syslog(LOG_ERR, "[%s] Failed to start outbound dispatch thread\n", TAG);
+        if (daemon_mode) {
+            g_daemon_running = false;
+        }
         return -1;
     }
     BOOT_LOG(&t0, "P5", "outbound dispatch thread started");
@@ -692,9 +746,11 @@ int ai_agent_main(int argc, char* argv[])
     BOOT_LOG(&t0, "P5", "network_watch thread started (async)");
 
     /* ── Phase 6: CLI thread — all services now in known state ── */
-    {
+    if (!skip_cli) {
         int rc = nsh_commands_start();
         BOOT_LOG_RC(&t0, "P6", "nsh_commands_start", rc);
+    } else {
+        BOOT_LOG(&t0, "P6", "nsh_commands skipped (daemon mode)");
     }
 
     syslog(LOG_INFO, "[%s] [boot +%ldms] AI Agent ready. Type 'help' in NSH for commands.\n",
@@ -752,5 +808,8 @@ int ai_agent_main(int argc, char* argv[])
 
     syslog(LOG_INFO, "[%s] Shutdown complete.\n", TAG);
 
+    if (daemon_mode) {
+        g_daemon_running = false;
+    }
     return 0;
 }

--- a/src/agent_main.c
+++ b/src/agent_main.c
@@ -137,29 +137,63 @@ bool agent_shutdown_requested(void)
 
 /* ── Network watcher (async) ──────────────────────────────────── */
 
-#ifdef CONFIG_AI_AGENT_NET_RPMSG
 static volatile bool g_net_services_started = false;
 
+static void start_network_dependent_services(void)
+{
+    if (g_net_services_started) {
+        return;
+    }
+
+    syslog(LOG_INFO, "[%s] Network connected: %s\n", TAG, network_get_ip());
+
+#if AGENT_SKILL_SYNC_ENABLED
+    if (skill_sync_from_bitable() != OK) {
+        syslog(LOG_WARNING,
+            "[%s] Bitable skill sync failed, using local skills\n", TAG);
+    }
+#endif
+
+#ifdef CONFIG_AI_AGENT_FEISHU
+    if (feishu_bot_start() != OK)
+        syslog(LOG_WARNING, "[%s] feishu_bot_start failed\n", TAG);
+#endif
+#ifndef AGENT_VG_HMI_LAZY_LOOP
+    if (agent_loop_start() != OK)
+        syslog(LOG_WARNING, "[%s] agent_loop_start failed\n", TAG);
+#endif
+#ifndef AGENT_VG_HMI_SKIP_WS
+    if (ws_server_start() != OK)
+        syslog(LOG_WARNING, "[%s] ws_server_start failed\n", TAG);
+#endif
+#ifdef CONFIG_AI_AGENT_NODE
+    if (node_client_start() != OK)
+        syslog(LOG_WARNING, "[%s] node_client_start failed\n", TAG);
+#endif
+#ifdef CONFIG_AI_AGENT_MQTT
+    if (mqtt_channel_start() != OK)
+        syslog(LOG_WARNING, "[%s] mqtt_channel_start failed\n", TAG);
+#endif
+#ifdef CONFIG_AI_AGENT_WEIXIN
+    if (weixin_channel_start() != OK)
+        syslog(LOG_WARNING, "[%s] weixin_channel_start failed\n", TAG);
+#endif
+
+    g_net_services_started = true;
+#ifdef AGENT_VG_HMI_LAZY_LOOP
+    syslog(LOG_INFO,
+        "[%s] HMI lazy mode: agent_loop starts on first ask\n", TAG);
+#endif
+    syslog(LOG_INFO, "[%s] All network services started!\n", TAG);
+}
+
+#ifdef CONFIG_AI_AGENT_NET_RPMSG
 static void net_state_change_cb(net_state_t state, void* arg)
 {
     (void)arg;
     if (state == NET_STATE_CONNECTED && !g_net_services_started) {
         syslog(LOG_INFO, "[%s] Network recovered, starting services\n", TAG);
-#ifdef CONFIG_AI_AGENT_FEISHU
-        feishu_bot_start();
-#endif
-        agent_loop_start();
-        ws_server_start();
-#ifdef CONFIG_AI_AGENT_NODE
-        node_client_start();
-#endif
-#ifdef CONFIG_AI_AGENT_MQTT
-        mqtt_channel_start();
-#endif
-#ifdef CONFIG_AI_AGENT_WEIXIN
-        weixin_channel_start();
-#endif
-        g_net_services_started = true;
+        start_network_dependent_services();
     } else if (state == NET_STATE_DISCONNECTED) {
         syslog(LOG_WARNING,
             "[%s] Network lost, services may be affected\n", TAG);
@@ -182,55 +216,41 @@ static void* network_watch_task(void* arg)
     network_wifi_reconnect();
 
     if (network_wait_connected(30000) == OK) {
-        syslog(LOG_INFO, "[%s] Network connected: %s\n", TAG, network_get_ip());
+        start_network_dependent_services();
+    } else {
+        syslog(LOG_WARNING,
+            "[%s] Network timeout — will retry until link is up.\n", TAG);
+    }
 
-#if AGENT_SKILL_SYNC_ENABLED
-        /* Sync skills from Bitable before starting agent loop */
-        if (skill_sync_from_bitable() != OK) {
-            syslog(LOG_WARNING, "[%s] Bitable skill sync failed, using local skills\n", TAG);
+#ifdef CONFIG_AI_AGENT_NET_RPMSG
+    network_register_listener(net_state_change_cb, NULL);
+#endif
+
+    /* Wi-Fi may join after the initial 30 s window; keep polling so ask/LLM
+     * works once vgnet reports a routable address. */
+    while (!g_shutdown_requested && !g_net_services_started) {
+        sleep(2);
+        if (network_is_connected()) {
+            syslog(LOG_INFO,
+                "[%s] Network connected (late), starting services\n", TAG);
+            start_network_dependent_services();
+        }
+    }
+
+    while (!g_shutdown_requested) {
+#ifdef AGENT_VG_HMI_LAZY_LOOP
+        if (agent_loop_is_requested() && !agent_loop_is_running()) {
+            if (agent_loop_start() == OK) {
+                syslog(LOG_INFO, "[%s] agent_loop started (lazy ask)\n", TAG);
+            }
+        }
+#else
+        if (network_is_connected() && !agent_loop_is_running()) {
+            agent_loop_start();
         }
 #endif
-
-#ifdef CONFIG_AI_AGENT_FEISHU
-        if (feishu_bot_start() != OK)
-            syslog(LOG_WARNING, "[%s] feishu_bot_start failed\n", TAG);
-#endif
-        if (agent_loop_start() != OK)
-            syslog(LOG_WARNING, "[%s] agent_loop_start failed\n", TAG);
-        if (ws_server_start() != OK)
-            syslog(LOG_WARNING, "[%s] ws_server_start failed\n", TAG);
-#ifdef CONFIG_AI_AGENT_NODE
-        if (node_client_start() != OK)
-            syslog(LOG_WARNING, "[%s] node_client_start failed\n", TAG);
-#endif
-#ifdef CONFIG_AI_AGENT_MQTT
-        if (mqtt_channel_start() != OK)
-            syslog(LOG_WARNING, "[%s] mqtt_channel_start failed\n", TAG);
-#endif
-#ifdef CONFIG_AI_AGENT_WEIXIN
-        if (weixin_channel_start() != OK)
-            syslog(LOG_WARNING, "[%s] weixin_channel_start failed\n", TAG);
-#endif
-
-        syslog(LOG_INFO, "[%s] All network services started!\n", TAG);
-
-#ifdef CONFIG_AI_AGENT_NET_RPMSG
-        g_net_services_started = true;
-#endif
-    } else {
-        syslog(LOG_WARNING, "[%s] Network timeout — net services not started.\n", TAG);
-        syslog(LOG_WARNING, "[%s] Use 'config_show' / 'set_*' CLI commands to configure.\n", TAG);
-    }
-
-#ifdef CONFIG_AI_AGENT_NET_RPMSG
-    /* Register listener for network state changes — auto-restart services on reconnect */
-    network_register_listener(net_state_change_cb, NULL);
-
-    /* Keep thread alive to handle reconnection events */
-    while (!g_shutdown_requested) {
         sleep(1);
     }
-#endif
 
     return NULL;
 }
@@ -550,12 +570,15 @@ int ai_agent_main(int argc, char* argv[])
     mkdir("/data/agent/skills", 0755);
     BOOT_LOG(&t0, "P0", "storage ready");
 
-    /* Memory info */
+#ifndef __NuttX__
+    /* mallinfo() walks every heap node; on NuttX this can assert if the heap
+     * is under pressure from large agent stacks — skip boot-time heap stats. */
     {
         struct mallinfo mi = mallinfo();
         syslog(LOG_INFO, "[%s] [boot +%ldms] heap: arena=%d free=%d used=%d\n",
             TAG, boot_ms(&t0), mi.arena, mi.fordblks, mi.uordblks);
     }
+#endif
 
     /* ── Phase 1: Core infrastructure ──────────────────────── */
     {
@@ -687,9 +710,17 @@ int ai_agent_main(int argc, char* argv[])
 #endif
 
     /* Cron + heartbeat don't need network */
+#ifndef CONFIG_VG_HMI
     cron_service_start();
     heartbeat_start();
     BOOT_LOG(&t0, "P5", "cron + heartbeat started");
+#else
+    /* VelaGuard HMI (SRAM-tight): keep the 4 KB heartbeat thread so the
+     * proactive tasks in HEARTBEAT.md (alarm interpretation, daily report)
+     * still fire; skip the cron poller. */
+    heartbeat_start();
+    BOOT_LOG(&t0, "P5", "heartbeat started, cron skipped (HMI SRAM save)");
+#endif
 
 #ifdef CONFIG_AI_AGENT_LVGL_UI
     if (lvgl_ui_channel_start() != OK)
@@ -738,7 +769,7 @@ int ai_agent_main(int argc, char* argv[])
 
     /* Network watcher thread: reconnect + wait + start net services */
     if (agent_task_create(network_watch_task, "net_watch",
-            AGENT_OUTBOUND_STACK, NULL,
+            AGENT_NET_WATCH_STACK, NULL,
             AGENT_OUTBOUND_PRIO)
         != OK) {
         syslog(LOG_WARNING, "[%s] Failed to start network_watch thread\n", TAG);

--- a/src/channels/nsh_commands.c
+++ b/src/channels/nsh_commands.c
@@ -25,6 +25,7 @@
 #include "channels/cmd_llm.h"
 #include "channels/cmd_voice.h"
 #include "core/message_bus.h"
+#include "core/agent_loop.h"
 #include "infra/config_store.h"
 #include "infra/cron_service.h"
 #include "infra/heartbeat.h"
@@ -593,6 +594,12 @@ static void cmd_ask(int argc, char** argv)
     msg.content = strdup(content);
     if (msg.content)
         message_bus_push_inbound(&msg);
+    if (network_is_connected()) {
+        agent_loop_ensure_started();
+#ifdef CONFIG_VG_HMI
+        printf("Ask queued; agent_loop starting in background...\n");
+#endif
+    }
     printf("Sent to agent: %s\n", content);
     syslog(LOG_INFO, "[agent] ask: %s\n", content);
 }

--- a/src/channels/nsh_commands.c
+++ b/src/channels/nsh_commands.c
@@ -70,6 +70,7 @@
 #endif
 
 static const char* TAG = "cli";
+static bool g_detach_quit = false;
 
 #define MAX_ARGS 8
 #define LINE_LEN 256
@@ -661,7 +662,9 @@ static void cmd_quit(void)
 {
     printf("Exiting agent...\n");
     fflush(stdout);
-    agent_request_shutdown();
+    if (!g_detach_quit) {
+        agent_request_shutdown();
+    }
 }
 
 static void cmd_launch_app(int argc, char** argv)
@@ -1087,4 +1090,15 @@ int nsh_commands_init(void)
 int nsh_commands_start(void)
 {
     return agent_task_create(cli_thread, "agent_cli", AGENT_CLI_STACK, NULL, AGENT_CLI_PRIO);
+}
+
+void nsh_commands_set_detach_quit(bool detach)
+{
+    g_detach_quit = detach;
+}
+
+int nsh_commands_run_interactive(void)
+{
+    cli_thread(NULL);
+    return OK;
 }

--- a/src/channels/nsh_commands.h
+++ b/src/channels/nsh_commands.h
@@ -40,3 +40,12 @@ int nsh_commands_init(void);
  * Call after all services are in a known state (post Phase 5).
  */
 int nsh_commands_start(void);
+
+/**
+ * Run CLI on the caller thread until the user types quit.
+ * Used when a --daemon agent is already running.
+ */
+int nsh_commands_run_interactive(void);
+
+/** When true, quit exits CLI only and leaves the daemon agent running. */
+void nsh_commands_set_detach_quit(bool detach);

--- a/src/core/agent_loop.c
+++ b/src/core/agent_loop.c
@@ -61,6 +61,23 @@ static const char* TAG = "agent";
 #define TOOL_OUTPUT_SIZE_MIN (2 * 1024)
 #endif
 
+/* Heap scan between ReAct phases: mallinfo walks the heap; with the
+ * mm_foreach corruption guard enabled (CONFIG_MM_RECORD_STACK builds)
+ * a smashed node is reported with the owning allocation's backtrace,
+ * which brackets the corrupting phase to a single step. */
+
+#ifdef CONFIG_VG_HMI
+#define VG_HEAP_SCAN(phase)                                   \
+    do {                                                      \
+        agent_mem_status_t st_;                               \
+        agent_mem_get_status(&st_);                           \
+        syslog(LOG_INFO, "[heapscan] %s free=%zu\n",          \
+            phase, st_.free_heap);                            \
+    } while (0)
+#else
+#define VG_HEAP_SCAN(phase)
+#endif
+
 /* ── Forward declarations ──────────────────────────────────── */
 
 static char* handle_slash_note(const agent_msg_t* msg);
@@ -1040,6 +1057,7 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
     name_repeat = 0;
     int last_total_tokens = 0;
     bool watchdog_fired = false;
+    VG_HEAP_SCAN("react_enter");
 
     /* Router: select and apply best backend before first LLM call.
      * Estimate complexity from the last user message. */
@@ -1076,6 +1094,7 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
 
         llm_response_t resp;
         struct timespec tv_start, tv_end;
+        VG_HEAP_SCAN("before_llm");
         mono_now(&tv_start);
         int err = llm_chat_tools(sys_prompt, messages, tools_json, &resp);
         mono_now(&tv_end);
@@ -1245,6 +1264,7 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
             break;
         }
 
+        VG_HEAP_SCAN("llm_done");
         syslog(LOG_INFO, "[%s] Tool iter %d: %d calls\n",
             TAG, iteration + 1, resp.call_count);
 
@@ -1266,8 +1286,10 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
         }
 
         add_assistant_message(messages, &resp);
+        VG_HEAP_SCAN("asst_added");
         add_tool_result_messages(messages, &resp, tool_output,
             tool_size, msg->channel, msg->chat_id);
+        VG_HEAP_SCAN("tools_done");
 
         /* Local tool shortcut: if the single tool in this round is a
          * local file op, skip the next LLM round and use the tool
@@ -1426,6 +1448,7 @@ static void* agent_loop_task(void* arg)
     size_t hist_size = AGENT_LLM_STREAM_BUF_SIZE;
     size_t tool_size = TOOL_OUTPUT_SIZE;
     syslog(LOG_INFO, "[%s] Agent loop started (HMI fixed buffers)\n", TAG);
+    VG_HEAP_SCAN("task_enter");
 #else
     agent_mem_get_status(&mem_st);
     syslog(LOG_INFO, "[%s] Agent loop started, free heap: %zu\n",
@@ -1476,6 +1499,7 @@ static void* agent_loop_task(void* arg)
 
     syslog(LOG_INFO, "[%s] Tools JSON loaded: %d bytes\n",
         TAG, tools_json ? (int)strlen(tools_json) : 0);
+    VG_HEAP_SCAN("loop_started");
 
     while (!agent_shutdown_requested()) {
         agent_msg_t msg;
@@ -1558,9 +1582,11 @@ static void* agent_loop_task(void* arg)
             skill_loader_refresh();
         }
 
+        VG_HEAP_SCAN("ctx_pre");
         context_build_system_prompt(sys_prompt, ctx_size);
         inject_session_context(sys_prompt, ctx_size,
             msg.channel, msg.chat_id);
+        VG_HEAP_SCAN("ctx_done");
 
         /* Refresh tools JSON — Node tools are dynamic */
         free(tools_json);

--- a/src/core/agent_loop.c
+++ b/src/core/agent_loop.c
@@ -52,6 +52,15 @@ static const char* TAG = "agent";
 #define TOOL_OUTPUT_SIZE_LARGE (16 * 1024)
 #define TOOL_OUTPUT_SIZE_MIN (2 * 1024)
 
+#ifdef CONFIG_VG_HMI
+#undef TOOL_OUTPUT_SIZE
+#undef TOOL_OUTPUT_SIZE_LARGE
+#undef TOOL_OUTPUT_SIZE_MIN
+#define TOOL_OUTPUT_SIZE (4 * 1024)
+#define TOOL_OUTPUT_SIZE_LARGE (8 * 1024)
+#define TOOL_OUTPUT_SIZE_MIN (2 * 1024)
+#endif
+
 /* ── Forward declarations ──────────────────────────────────── */
 
 static char* handle_slash_note(const agent_msg_t* msg);
@@ -1411,6 +1420,13 @@ static void* agent_loop_task(void* arg)
     (void)arg;
     agent_mem_status_t mem_st;
 
+#ifdef CONFIG_VG_HMI
+    /* Avoid mallinfo() at start — can assert under HMI heap pressure. */
+    size_t ctx_size = AGENT_CONTEXT_BUF_SIZE;
+    size_t hist_size = AGENT_LLM_STREAM_BUF_SIZE;
+    size_t tool_size = TOOL_OUTPUT_SIZE;
+    syslog(LOG_INFO, "[%s] Agent loop started (HMI fixed buffers)\n", TAG);
+#else
     agent_mem_get_status(&mem_st);
     syslog(LOG_INFO, "[%s] Agent loop started, free heap: %zu\n",
         TAG, mem_st.free_heap);
@@ -1421,6 +1437,7 @@ static void* agent_loop_task(void* arg)
         AGENT_LLM_STREAM_BUF_SIZE, 8 * 1024);
     size_t tool_size = agent_mem_safe_size(
         TOOL_OUTPUT_SIZE, TOOL_OUTPUT_SIZE_MIN);
+#endif
 
     char* sys_prompt = calloc(1, ctx_size);
     char* history_json = calloc(1, hist_size);
@@ -1438,8 +1455,12 @@ static void* agent_loop_task(void* arg)
         TAG, ctx_size, hist_size, tool_size);
 
     /* Initialize memory pool for parallel tool outputs */
+#ifdef CONFIG_VG_HMI
+    size_t pool_buf_size = TOOL_OUTPUT_SIZE_LARGE;
+#else
     size_t pool_buf_size = agent_mem_safe_size(
         TOOL_OUTPUT_SIZE_LARGE, TOOL_OUTPUT_SIZE_MIN);
+#endif
     if (agent_pool_init(&s_tool_pool, pool_buf_size,
             AGENT_MAX_TOOL_CALLS)
         == OK) {
@@ -1473,6 +1494,7 @@ static void* agent_loop_task(void* arg)
         syslog(LOG_INFO, "[%s] Processing message from %s:%s\n",
             TAG, msg.channel, msg.chat_id);
 
+#ifndef CONFIG_VG_HMI
         /* Check memory pressure */
         agent_mem_get_status(&mem_st);
         if (mem_st.free_heap < AGENT_MEM_RESERVE_BYTES) {
@@ -1493,6 +1515,7 @@ static void* agent_loop_task(void* arg)
             free(msg.content);
             continue;
         }
+#endif
 
         /* Slash commands — fast path, bypass LLM */
         char* reply = handle_slash_command(&msg);
@@ -1582,6 +1605,68 @@ static void* agent_loop_task(void* arg)
 
 /* ── Public interface ─────────────────────────────────────── */
 
+static volatile bool s_agent_loop_started = false;
+#ifdef CONFIG_VG_HMI
+static volatile bool s_agent_loop_requested = false;
+#endif
+
+#ifdef CONFIG_VG_HMI
+/* HMI builds cannot allocate a 16 KB pthread stack from heap — use BSS. */
+static uint8_t s_agent_loop_stack[AGENT_AI_AGENT_STACK]
+    __attribute__((aligned(8)));
+
+static int agent_loop_start_static_stack(void)
+{
+    _agent_task_args_t* ta = malloc(sizeof(_agent_task_args_t));
+
+    if (!ta) {
+        return ERROR;
+    }
+
+    ta->func = agent_loop_task;
+    ta->arg = NULL;
+    ta->stack_size = AGENT_AI_AGENT_STACK;
+
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setstack(&attr, s_agent_loop_stack, sizeof(s_agent_loop_stack));
+
+    struct sched_param sp;
+    sp.sched_priority = AGENT_AI_AGENT_PRIO;
+    pthread_attr_setschedparam(&attr, &sp);
+    pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
+    pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+
+    pthread_t tid;
+    int r = pthread_create(&tid, &attr, _agent_task_shim, ta);
+    pthread_attr_destroy(&attr);
+    if (r != 0) {
+        free(ta);
+        syslog(LOG_ERR, "[%s] agent_loop pthread_create failed: %d\n", TAG, r);
+        return ERROR;
+    }
+    pthread_detach(tid);
+    return OK;
+}
+#endif
+
+bool agent_loop_is_running(void)
+{
+    return s_agent_loop_started;
+}
+
+#ifdef CONFIG_VG_HMI
+void agent_loop_request_start(void)
+{
+    s_agent_loop_requested = true;
+}
+
+bool agent_loop_is_requested(void)
+{
+    return s_agent_loop_requested;
+}
+#endif
+
 int agent_loop_init(void)
 {
     syslog(LOG_INFO, "[%s] Agent loop initialized\n", TAG);
@@ -1590,12 +1675,48 @@ int agent_loop_init(void)
 
 int agent_loop_start(void)
 {
+    if (s_agent_loop_started) {
+        return OK;
+    }
+
+#ifdef CONFIG_VG_HMI
+    /* Do NOT call mallinfo() here — under HMI memory pressure it can assert. */
+    int ret = agent_loop_start_static_stack();
+#else
+    agent_mem_status_t st;
+    agent_mem_get_status(&st);
+    if (st.free_heap
+        < (size_t)AGENT_AI_AGENT_STACK + AGENT_MEM_RESERVE_BYTES) {
+        syslog(LOG_WARNING,
+            "[%s] Defer agent_loop: free heap %zu (need %u)\n",
+            TAG, st.free_heap,
+            (unsigned)(AGENT_AI_AGENT_STACK + AGENT_MEM_RESERVE_BYTES));
+        return ERROR;
+    }
+
     int ret = agent_task_create(agent_loop_task, "agent_loop",
         AGENT_AI_AGENT_STACK, NULL, AGENT_AI_AGENT_PRIO);
+#endif
 
     if (ret != OK) {
         syslog(LOG_ERR,
             "[%s] Failed to create agent_loop task\n", TAG);
+    } else {
+        s_agent_loop_started = true;
+#ifdef CONFIG_VG_HMI
+        s_agent_loop_requested = false;
+#endif
     }
     return ret;
+}
+
+int agent_loop_ensure_started(void)
+{
+#ifdef CONFIG_VG_HMI
+    /* CLI stack is tight — only request; network_watch starts the loop. */
+    agent_loop_request_start();
+    return OK;
+#else
+    return agent_loop_start();
+#endif
 }

--- a/src/core/agent_loop.c
+++ b/src/core/agent_loop.c
@@ -42,7 +42,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <sys/time.h>
+#include <time.h>
 
 #include "cJSON.h"
 
@@ -65,31 +65,33 @@ static bool llm_call_timed_out(uint32_t latency_ms);
 #define LLM_TIMEOUT_TASK_COMPLETE_MSG \
     "任务已完成，但生成确认消息超时。"
 
-/* ── Clock-safe elapsed time calculation ───────────────────── */
+/* ── Monotonic elapsed time (immune to wall-clock jumps) ───── */
 
-static inline uint32_t calc_elapsed_ms(const struct timeval* t0,
-    const struct timeval* t1)
+static inline void mono_now(struct timespec* ts)
 {
-    int32_t sec_diff = (int32_t)(t1->tv_sec - t0->tv_sec);
-    int32_t usec_diff = (int32_t)(t1->tv_usec - t0->tv_usec);
+    clock_gettime(CLOCK_MONOTONIC, ts);
+}
 
-    /* Clock went backwards (NTP jump, manual adjustment) */
+static inline uint32_t calc_elapsed_ms(const struct timespec* t0,
+    const struct timespec* t1)
+{
+    int64_t sec_diff = (int64_t)(t1->tv_sec - t0->tv_sec);
+    int64_t nsec_diff = (int64_t)(t1->tv_nsec - t0->tv_nsec);
+
     if (sec_diff < 0) {
-        syslog(LOG_WARNING, "[%s] Clock went backwards, ignoring\n", TAG);
         return 0;
     }
 
-    /* Microsecond borrow */
-    if (usec_diff < 0) {
+    if (nsec_diff < 0) {
         sec_diff--;
-        usec_diff += 1000000;
+        nsec_diff += 1000000000L;
     }
 
     if (sec_diff < 0) {
         return 0;
     }
 
-    return (uint32_t)sec_diff * 1000 + (uint32_t)usec_diff / 1000;
+    return (uint32_t)sec_diff * 1000 + (uint32_t)(nsec_diff / 1000000L);
 }
 
 /* ── Memory pool (pre-allocated tool output buffers) ───────── */
@@ -105,12 +107,12 @@ static void add_assistant_message(cJSON* messages, const llm_response_t* resp)
 
     if (resp->text && resp->text_len > 0) {
         cJSON_AddStringToObject(asst_msg, "content", resp->text);
-    } else {
-        cJSON_AddNullToObject(asst_msg, "content");
     }
+    /* Omit content when empty — MiMo rejects explicit null (400 Invalid JSON). */
 
-    /* Kimi thinking mode: echo back reasoning_content or the API returns 400 */
-    if (resp->reasoning_content && resp->reasoning_content[0]) {
+    /* Kimi thinking mode only — other hosts reject unknown fields. */
+    if (resp->reasoning_content && resp->reasoning_content[0]
+        && llm_proxy_echo_reasoning()) {
         cJSON_AddStringToObject(asst_msg, "reasoning_content",
             resp->reasoning_content);
     }
@@ -819,10 +821,10 @@ static char* force_finish_reply(const char* system_prompt,
 
     llm_response_t resp;
     char* result = NULL;
-    struct timeval t0, t1;
-    gettimeofday(&t0, NULL);
+    struct timespec t0, t1;
+    mono_now(&t0);
     int err = llm_chat_tools(system_prompt, messages, NULL, &resp);
-    gettimeofday(&t1, NULL);
+    mono_now(&t1);
     uint32_t ms = calc_elapsed_ms(&t0, &t1);
     bool timed_out = llm_call_timed_out(ms);
 
@@ -989,10 +991,10 @@ static char* handle_task_complete(const char* sys_prompt, cJSON* messages,
 
     llm_response_t final_resp;
     char* result = NULL;
-    struct timeval t0, t1;
-    gettimeofday(&t0, NULL);
+    struct timespec t0, t1;
+    mono_now(&t0);
     int err = llm_chat_tools(sys_prompt, messages, NULL, &final_resp);
-    gettimeofday(&t1, NULL);
+    mono_now(&t1);
     uint32_t ms = calc_elapsed_ms(&t0, &t1);
     bool timed_out = llm_call_timed_out(ms);
 
@@ -1064,10 +1066,10 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
         send_working_status(msg, iteration);
 
         llm_response_t resp;
-        struct timeval tv_start, tv_end;
-        gettimeofday(&tv_start, NULL);
+        struct timespec tv_start, tv_end;
+        mono_now(&tv_start);
         int err = llm_chat_tools(sys_prompt, messages, tools_json, &resp);
-        gettimeofday(&tv_end, NULL);
+        mono_now(&tv_end);
         uint32_t latency_ms = calc_elapsed_ms(&tv_start, &tv_end);
 
         /* Router failover: on LLM call failure, try next backend */
@@ -1083,10 +1085,10 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
                 router_idx = next_idx;
                 trace.backend_idx = next_idx;
                 llm_response_free(&resp);
-                gettimeofday(&tv_start, NULL);
+                mono_now(&tv_start);
                 err = llm_chat_tools(sys_prompt, messages,
                     tools_json, &resp);
-                gettimeofday(&tv_end, NULL);
+                mono_now(&tv_end);
                 latency_ms = calc_elapsed_ms(&tv_start, &tv_end);
             }
         }
@@ -1183,10 +1185,10 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
                     router_idx = prem_idx;
                     trace.backend_idx = prem_idx;
 
-                    gettimeofday(&tv_start, NULL);
+                    mono_now(&tv_start);
                     err = llm_chat_tools(sys_prompt, messages,
                         tools_json, &resp);
-                    gettimeofday(&tv_end, NULL);
+                    mono_now(&tv_end);
                     latency_ms = calc_elapsed_ms(&tv_start, &tv_end);
 
                     /* Watchdog check on cascade retry */
@@ -1261,6 +1263,8 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
         /* Local tool shortcut: if the single tool in this round is a
          * local file op, skip the next LLM round and use the tool
          * output directly as the reply. Saves ~2s.
+         * list_dir is excluded — it is almost always a discovery step
+         * before read_file / run_shell / write_file (e.g. Skill workflows).
          * Restricted to call_count == 1: the parallel path does not
          * write into tool_output, so multi-call rounds must go through
          * the LLM to aggregate results (and tool_output would be stale
@@ -1270,8 +1274,7 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
             for (int i = 0; i < resp.call_count; i++) {
                 if (strcmp(resp.calls[i].name, "read_file") != 0
                     && strcmp(resp.calls[i].name, "write_file") != 0
-                    && strcmp(resp.calls[i].name, "edit_file") != 0
-                    && strcmp(resp.calls[i].name, "list_dir") != 0) {
+                    && strcmp(resp.calls[i].name, "edit_file") != 0) {
                     all_local = false;
                     break;
                 }

--- a/src/core/agent_loop.h
+++ b/src/core/agent_loop.h
@@ -30,6 +30,13 @@ extern "C" {
 
 int agent_loop_init(void);
 int agent_loop_start(void);
+/** Start agent_loop once; safe to call after late Wi-Fi connect. */
+int agent_loop_ensure_started(void);
+bool agent_loop_is_running(void);
+#ifdef CONFIG_VG_HMI
+void agent_loop_request_start(void);
+bool agent_loop_is_requested(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/core/agent_mem.h
+++ b/src/core/agent_mem.h
@@ -61,7 +61,9 @@ static inline void agent_mem_get_status(agent_mem_status_t* st)
  * available free heap. Reserves AGENT_MEM_RESERVE_BYTES for
  * other subsystems.
  */
+#ifndef AGENT_MEM_RESERVE_BYTES
 #define AGENT_MEM_RESERVE_BYTES (32 * 1024)
+#endif
 
 static inline size_t agent_mem_safe_size(size_t requested, size_t min_size)
 {

--- a/src/core/context_builder.c
+++ b/src/core/context_builder.c
@@ -97,7 +97,7 @@ int context_build_system_prompt(char *buf, size_t size)
      * lookup errors (romfs doesn't have "CST-8" zoneinfo file). */
     time_t now = time(NULL);
     struct tm tm_now;
-    time_t local_epoch = now + 8 * 3600;
+    time_t local_epoch = now + AGENT_TIME_OFFSET_SEC;
     gmtime_r(&local_epoch, &tm_now);
     char time_str[64];
     strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", &tm_now);

--- a/src/infra/heartbeat.c
+++ b/src/infra/heartbeat.c
@@ -22,6 +22,7 @@
 
 #include "infra/heartbeat.h"
 #include "agent_config.h"
+#include "core/agent_loop.h"
 #include "core/message_bus.h"
 
 #include <stdio.h>
@@ -118,6 +119,10 @@ static bool heartbeat_send(void)
     }
 
     syslog(LOG_INFO, "[%s] Triggered agent check\n", TAG);
+
+    /* Lazy-loop builds (VelaGuard HMI) only start agent_loop on demand;
+     * make sure the queued heartbeat prompt actually gets consumed. */
+    agent_loop_ensure_started();
     return true;
 }
 

--- a/src/llm/llm_proxy.c
+++ b/src/llm/llm_proxy.c
@@ -61,6 +61,37 @@ bool is_openai_compat_host(const char* host)
         || strstr(host, "xiaomimimo.com");
 }
 
+bool llm_proxy_echo_reasoning(void)
+{
+    char host[128];
+
+    pthread_mutex_lock(&s_llm_lock);
+    memcpy(host, s_llm_host, sizeof(host));
+    pthread_mutex_unlock(&s_llm_lock);
+
+    return strstr(host, "moonshot") != NULL
+        || strstr(host, "kimi") != NULL;
+}
+
+/* MiMo/OpenAI-compat: null content and unknown fields break the API. */
+static void llm_sanitize_messages_for_api(cJSON* msgs)
+{
+    cJSON* msg;
+
+    cJSON_ArrayForEach(msg, msgs)
+    {
+        cJSON* content = cJSON_GetObjectItem(msg, "content");
+
+        if (content && cJSON_IsNull(content)) {
+            cJSON_DeleteItemFromObject(msg, "content");
+        }
+
+        if (!llm_proxy_echo_reasoning()) {
+            cJSON_DeleteItemFromObject(msg, "reasoning_content");
+        }
+    }
+}
+
 
 int resp_buf_init(resp_buf_t* rb, size_t initial_cap)
 {
@@ -722,6 +753,7 @@ int llm_chat_tools(const char* system_prompt, cJSON* messages,
     cJSON_AddStringToObject(sys_msg, "role", "system");
     cJSON_AddStringToObject(sys_msg, "content", system_prompt);
     cJSON_InsertItemInArray(msgs, 0, sys_msg);
+    llm_sanitize_messages_for_api(msgs);
     cJSON_AddItemToObject(body, "messages", msgs);
 
     /* Convert tools to OpenAI format */

--- a/src/llm/llm_proxy.h
+++ b/src/llm/llm_proxy.h
@@ -78,6 +78,8 @@ int llm_chat_tools(const char* system_prompt,
     const char* tools_json,
     llm_response_t* resp);
 
+bool llm_proxy_echo_reasoning(void);
+
 /** Vision chat: send text + base64 image to a vision-capable model.
  *  image_b64 is the raw base64 string (no data: prefix).
  *  mime_type: "image/jpeg", "image/png", etc. NULL defaults to "image/jpeg". */

--- a/src/tools/tool_files.c
+++ b/src/tools/tool_files.c
@@ -38,6 +38,63 @@ static const char *TAG = "tool_files";
 
 #define MAX_FILE_SIZE (32 * 1024)
 
+/* VelaGuard reports/alarms live outside AGENT_DATA_DIR but on the same /data mount. */
+#define VG_DATA_ROOT "/data/velaguard"
+
+static bool path_under_resolved_root(const char *resolved, const char *logical_root)
+{
+    char root[PATH_MAX];
+    const char *base = logical_root;
+
+    if (realpath(logical_root, root) != NULL) {
+        base = root;
+    }
+
+    size_t len = strlen(base);
+    return strncmp(resolved, base, len) == 0
+        && (resolved[len] == '/' || resolved[len] == '\0');
+}
+
+static bool logical_path_allowed(const char *path)
+{
+    size_t agent_len = strlen(AGENT_DATA_DIR);
+
+    if (strncmp(path, AGENT_DATA_DIR, agent_len) == 0
+        && (path[agent_len] == '/' || path[agent_len] == '\0')) {
+        return true;
+    }
+
+    if (strncmp(path, VG_DATA_ROOT, sizeof(VG_DATA_ROOT) - 1) == 0
+        && (path[sizeof(VG_DATA_ROOT) - 1] == '/'
+            || path[sizeof(VG_DATA_ROOT) - 1] == '\0')) {
+        return true;
+    }
+
+    return false;
+}
+
+static bool path_has_prefix(const char *path, const char *prefix)
+{
+    if (!prefix || prefix[0] == '\0') {
+        return true;
+    }
+
+    size_t plen = strlen(prefix);
+    while (plen > 0 && prefix[plen - 1] == '/') {
+        plen--;
+    }
+
+    if (strlen(path) < plen) {
+        return false;
+    }
+
+    if (strncmp(path, prefix, plen) != 0) {
+        return false;
+    }
+
+    return path[plen] == '\0' || path[plen] == '/';
+}
+
 /**
  * Validate that path resolves to a location under AGENT_DATA_DIR.
  * Uses realpath() to resolve symlinks, preventing symlink escape attacks.
@@ -49,35 +106,27 @@ static bool validate_path(const char *path)
         return false;
     }
 
-    size_t dlen = strlen(AGENT_DATA_DIR);
-
-    /* Quick reject: raw path must at least start with data dir */
-    if (strncmp(path, AGENT_DATA_DIR, dlen) != 0
-        || (path[dlen] != '/' && path[dlen] != '\0')) {
-        return false;
-    }
-
     /* Reject explicit traversal components */
     if (strstr(path, "..") != NULL) {
         return false;
     }
 
-    /* Resolve symlinks to get the real path */
+    if (!logical_path_allowed(path)) {
+        return false;
+    }
+
+    /* Resolve symlinks (/data -> /mnt/emmc/data) and verify physical path. */
     char resolved[PATH_MAX];
 
     if (realpath(path, resolved) != NULL) {
-        /* File exists — verify resolved path is still under data dir */
-        if (strncmp(resolved, AGENT_DATA_DIR, dlen) != 0
-            || (resolved[dlen] != '/' && resolved[dlen] != '\0')) {
+        if (!path_under_resolved_root(resolved, AGENT_DATA_DIR)
+            && !path_under_resolved_root(resolved, VG_DATA_ROOT)) {
             syslog(LOG_WARNING,
-                   "[%s] Path escaped data dir via symlink: %s -> %s\n",
+                   "[%s] Path escaped allowed data dirs via symlink: %s -> %s\n",
                    TAG, path, resolved);
             return false;
         }
     }
-
-    /* If realpath fails (file doesn't exist yet), the raw path checks
-     * above are sufficient — no symlink to follow. */
 
     return true;
 }
@@ -115,10 +164,18 @@ static bool is_write_protected(const char *path)
 static void ensure_parent_dirs(const char *path)
 {
     char tmp[512];
+    size_t start;
+
     snprintf(tmp, sizeof(tmp), "%s", path);
 
-    /* Walk from the first '/' after AGENT_DATA_DIR to the last '/' */
-    size_t start = strlen(AGENT_DATA_DIR);
+    if (strncmp(path, AGENT_DATA_DIR, strlen(AGENT_DATA_DIR)) == 0) {
+        start = strlen(AGENT_DATA_DIR);
+    } else if (strncmp(path, VG_DATA_ROOT, sizeof(VG_DATA_ROOT) - 1) == 0) {
+        start = sizeof(VG_DATA_ROOT) - 1;
+    } else {
+        return;
+    }
+
     for (char *p = tmp + start; *p; p++) {
         if (*p == '/') {
             *p = '\0';
@@ -141,7 +198,8 @@ int tool_read_file_execute(const char *input_json, char *output, size_t output_s
     const char *path = cJSON_GetStringValue(cJSON_GetObjectItem(root, "path"));
     if (!validate_path(path)) {
         snprintf(output, output_size,
-                 "Error: path must start with %s/ and must not contain '..'", AGENT_DATA_DIR);
+                 "Error: path must be under %s/ or %s/ and must not contain '..'",
+                 AGENT_DATA_DIR, VG_DATA_ROOT);
         cJSON_Delete(root);
         return ERROR;
     }
@@ -180,7 +238,8 @@ int tool_write_file_execute(const char *input_json, char *output, size_t output_
 
     if (!validate_path(path)) {
         snprintf(output, output_size,
-                 "Error: path must start with %s/ and must not contain '..'", AGENT_DATA_DIR);
+                 "Error: path must be under %s/ or %s/ and must not contain '..'",
+                 AGENT_DATA_DIR, VG_DATA_ROOT);
         cJSON_Delete(root);
         return ERROR;
     }
@@ -239,7 +298,8 @@ int tool_edit_file_execute(const char *input_json, char *output, size_t output_s
 
     if (!validate_path(path)) {
         snprintf(output, output_size,
-                 "Error: path must start with %s/ and must not contain '..'", AGENT_DATA_DIR);
+                 "Error: path must be under %s/ or %s/ and must not contain '..'",
+                 AGENT_DATA_DIR, VG_DATA_ROOT);
         cJSON_Delete(root);
         return ERROR;
     }
@@ -347,7 +407,7 @@ static size_t list_dir_recursive(const char *dir_path, const char *prefix,
         char full_path[512];
         snprintf(full_path, sizeof(full_path), "%s/%s", dir_path, ent->d_name);
 
-        if (prefix && strncmp(full_path, prefix, strlen(prefix)) != 0) continue;
+        if (prefix && !path_has_prefix(full_path, prefix)) continue;
 
         struct stat st;
         if (stat(full_path, &st) == 0 && S_ISDIR(st.st_mode)) {

--- a/src/tools/tool_get_time.c
+++ b/src/tools/tool_get_time.c
@@ -170,7 +170,7 @@ int tool_get_time_execute(const char *input_json, char *output, size_t output_si
          * which fails for POSIX TZ strings like "CST-8" and spams
          * ERROR logs.  We bypass this by computing UTC+8 manually. */
         struct tm utc_tm;
-        time_t local_epoch = now + 8 * 3600;  /* UTC+8 */
+        time_t local_epoch = now + AGENT_TIME_OFFSET_SEC;
         gmtime_r(&local_epoch, &utc_tm);
 
         char time_str[64];

--- a/src/tools/tool_shell.c
+++ b/src/tools/tool_shell.c
@@ -90,7 +90,10 @@ static const char *s_allowed[] = {
     "set_gateway", "set_mqtt",
     "session_list", "memory_read",
     "mcp_list", "mcp_discover",
-    
+
+    /* VelaGuard read-only bring-up tools (stage1 ai_agent) */
+    "vgmodbus", "vgstats", "vgcfg", "vgnet",
+
     NULL
 };
 #endif
@@ -510,27 +513,31 @@ int tool_run_shell_execute(const char *input_json, char *output, size_t output_s
 
     cJSON_Delete(root);
 
-    if (ret != OK) {
-        snprintf(output, output_size, "{\"error\":\"Command failed: %s\"}", command);
+    /* Always return structured JSON so the LLM sees stdout even on non-zero exit. */
+    {
+        int exit_code = (ret == OK) ? 0 : 1;
+        cJSON *result = cJSON_CreateObject();
+
+        cJSON_AddNumberToObject(result, "exit_code", exit_code);
+        cJSON_AddStringToObject(result, "output", cmd_buf);
+        if (exit_code != 0) {
+            cJSON_AddStringToObject(result, "error", "non-zero exit");
+        }
+
+        char *json_str = cJSON_PrintUnformatted(result);
+        cJSON_Delete(result);
         free(cmd_buf);
-        return ERROR;
-    }
 
-    /* Build JSON result */
-    cJSON *result = cJSON_CreateObject();
-    cJSON_AddNumberToObject(result, "exit_code", 0);
-    cJSON_AddStringToObject(result, "output", cmd_buf);
-    free(cmd_buf);
+        if (!json_str) {
+            snprintf(output, output_size, "{\"exit_code\":1,\"output\":\"\"}");
+            return ERROR;
+        }
 
-    char *json_str = cJSON_PrintUnformatted(result);
-    cJSON_Delete(result);
-
-    if (json_str) {
         strncpy(output, json_str, output_size - 1);
         output[output_size - 1] = '\0';
-        syslog(LOG_INFO, "[%s] Result: %d bytes\n", TAG, (int)strlen(output));
         free(json_str);
+        syslog(LOG_INFO, "[%s] Result: %d bytes (exit=%d)\n",
+            TAG, (int)strlen(output), exit_code);
+        return OK;
     }
-
-    return OK;
 }

--- a/src/tools/tool_shell.c
+++ b/src/tools/tool_shell.c
@@ -161,6 +161,19 @@ static int is_blocked(const char *cmd)
     const char *basename = strrchr(first, '/');
     const char *name = basename ? basename + 1 : first;
 
+    /* VelaGuard: point-table mutation stays off the Agent allow-list. */
+    if (strcmp(name, "vgpoint") == 0 || strcmp(name, "vgdiscover") == 0) {
+        return 1;
+    }
+    if (strcmp(name, "vgcfg") == 0) {
+        while (cmd[i] == ' ') i++;
+        if (strncmp(cmd + i, "dump", 4) != 0)
+            return 1;
+        if (cmd[i + 4] != '\0' && cmd[i + 4] != ' ')
+            return 1;
+        return 0;
+    }
+
     /* Check whitelist first */
     for (int k = 0; s_allowed[k]; k++) {
         if (strcmp(name, s_allowed[k]) == 0)


### PR DESCRIPTION
Contest: contest2026_004 Team Falcons / VelaGuard. See FoLeaf/contest2026_004_TeamFalcons.

## What

VelaGuard runs `ai_agent` on **STM32H750B-DK** (Cortex-M7, ~1 MB SRAM) next to an LVGL HMI. This PR carries the changes needed for that board:

- **Daemon attach** (`--daemon` autostart, `ai_agent` on NSH attaches an interactive CLI; `quit` detaches).
- **SRAM-tight HMI mode** under `CONFIG_VG_HMI`: smaller stacks/buffers, static-stack lazy `agent_loop`, no `mallinfo()` probes, heartbeat kept (4 KB) with cron skipped, late-network retry so a Wi-Fi failover still enables `ask`.
- **Tool-layer guard for industrial buses**: `run_shell` allow-list denies `vgpoint` / `vgdiscover` and only permits `vgcfg dump`; `read_file` / `write_file` are limited to `/data/agent` and `/data/velaguard`.
- Robustness: monotonic LLM watchdog, wall clock seeded before TLS, null assistant content sanitized for MiMo, `run_shell` always returns JSON, `AGENT_LLM_TIMEOUT_SEC` = 120 for multi-tool report flows.

## Why

The AI-hardware track requires proactive + execute scenarios on device. VelaGuard's alarm interpretation and daily report are driven by `HEARTBEAT.md`, so the heartbeat thread must survive the HMI memory budget, while the Agent must never be able to write to a live Modbus bus.

## Verification

- `stm32h750b-dk:velaguard-lvgl` builds via `contest2026_004_TeamFalcons/scripts/build.sh`.
- Board acceptance scripts: `scripts/stage1_agent_accept_nsh.txt`, `scripts/stage1_agent_ops_accept_nsh.txt` in the team repository.
- All `CONFIG_VG_HMI` paths are `#ifdef`-guarded; other boards are unaffected except the VelaGuard command names on the shell deny-list.
