### PR TITLE
rpg: multi-role play with follow-up windows and session isolation

### DIFF
--- a/include/agent_config.h
+++ b/include/agent_config.h
@@ -249,6 +249,7 @@
 #define AGENT_CFG_KEY_FEISHU_USER_TOKEN "feishu_user_token"
 #define AGENT_CFG_KEY_LLM_HOST "llm_host"
 #define AGENT_CFG_KEY_LLM_PATH "llm_path"
+#define AGENT_CFG_KEY_LLM_THINKING "llm_thinking"
 #define AGENT_CFG_KEY_VISION_MODEL "vision_model"
 #define AGENT_CFG_KEY_VISION_HOST "vision_host"
 #define AGENT_CFG_KEY_VISION_API_KEY "vision_api_key"
@@ -293,6 +294,7 @@
 #define AGENT_CHAN_FEISHU "feishu"
 #define AGENT_CHAN_MQTT "mqtt"
 #define AGENT_CHAN_WEIXIN "weixin"
+#define AGENT_CHAN_LOCAL_CLIENT "local_client"
 #ifdef CONFIG_FEATURE_SYSTEM_VELACLAW
 #define AGENT_CHAN_QUICKAPP "quickapp"
 #endif

--- a/include/velaclaw/client.h
+++ b/include/velaclaw/client.h
@@ -6,6 +6,13 @@ typedef struct velaclaw_client_s velaclaw_client_t;
 typedef struct {
     const char* text;
     int timeout_ms;
+
+    /* Optional session id. When non-NULL and non-empty, ai_agent keys this
+     * turn's conversation history under this chat_id instead of the client's
+     * app_id. Used by the on-device app to keep a long-running story/RPG
+     * session's history separate from ordinary free chat. NULL or "" means
+     * "use the client's app_id" (the default, unchanged behaviour). */
+    const char* chat_id;
 } velaclaw_ask_req_t;
 
 velaclaw_client_t* velaclaw_client_open(const char* name);
@@ -13,5 +20,20 @@ void velaclaw_client_close(velaclaw_client_t* c);
 int velaclaw_ask(velaclaw_client_t* c,
     const velaclaw_ask_req_t* req,
     void (*cb)(int, const char*, void*), void* cookie);
+
+/* Register a persistent callback for UNSOLICITED inbound messages pushed to
+ * this client's channel (e.g. cron-fired reminders) while no velaclaw_ask is
+ * in flight. When async_cb is set (an ask is pending), ask replies take
+ * precedence and notify_cb is not called. `status` is 1 for a partial
+ * streaming fragment, 0 for the final/complete message. */
+void velaclaw_set_notify_callback(velaclaw_client_t* c,
+    void (*cb)(int, const char*, void*), void* cookie);
+
+/* Publish an arbitrary message onto the ai_agent outbound bus, addressed to a
+ * specific channel/chat_id (e.g. channel "mqtt" to reach a parent's MQTT
+ * session). Used by the on-device app to report events — such as a child
+ * confirming a reminder — back to a remote channel. Returns 0 on success. */
+int velaclaw_publish(velaclaw_client_t* c,
+    const char* channel, const char* chat_id, const char* text);
 
 #endif

--- a/src/core/agent_loop.c
+++ b/src/core/agent_loop.c
@@ -136,6 +136,20 @@ static void add_assistant_message(cJSON* messages, const llm_response_t* resp)
     cJSON_AddItemToArray(messages, asst_msg);
 }
 
+/* True for remote parent channels (MQTT/Feishu/WebSocket/WeChat/QuickApp).
+ * Reminders scheduled from these are meant for the child, not the sender. */
+static bool is_remote_parent_channel(const char* channel)
+{
+    return strcmp(channel, AGENT_CHAN_MQTT) == 0
+        || strcmp(channel, AGENT_CHAN_FEISHU) == 0
+        || strcmp(channel, AGENT_CHAN_WEBSOCKET) == 0
+        || strcmp(channel, AGENT_CHAN_WEIXIN) == 0
+#ifdef CONFIG_FEATURE_SYSTEM_VELACLAW
+        || strcmp(channel, AGENT_CHAN_QUICKAPP) == 0
+#endif
+        ;
+}
+
 /* Auto-inject channel/chat_id into cron_add input JSON. */
 static char* inject_cron_context(const char* tool_name,
     const char* input_json, const char* channel, const char* chat_id)
@@ -156,6 +170,23 @@ static char* inject_cron_context(const char* tool_name,
     cJSON_DeleteItemFromObject(root, "chat_id");
     cJSON_AddStringToObject(root, "channel", channel);
     cJSON_AddStringToObject(root, "chat_id", chat_id);
+
+    /* A reminder scheduled from a remote parent channel is for the child:
+     * speak it on-device (local_client), and report the child's confirmation
+     * back to the parent's own channel/chat_id. On-device requests
+     * (local_client/voice/cli) keep their original destination and do not
+     * get a confirmation report. */
+    if (is_remote_parent_channel(channel)) {
+        cJSON_DeleteItemFromObject(root, "report_channel");
+        cJSON_DeleteItemFromObject(root, "report_chat_id");
+        cJSON_AddStringToObject(root, "report_channel", channel);
+        cJSON_AddStringToObject(root, "report_chat_id", chat_id);
+
+        cJSON_DeleteItemFromObject(root, "channel");
+        cJSON_DeleteItemFromObject(root, "chat_id");
+        cJSON_AddStringToObject(root, "channel", AGENT_CHAN_LOCAL_CLIENT);
+        cJSON_AddStringToObject(root, "chat_id", "kid_buddy");
+    }
 
     char* patched = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
@@ -872,6 +903,36 @@ static void dispatch_response(const agent_msg_t* msg,
     }
 }
 
+/* ── Streaming partial dispatch (on-device GUI / local_client) ── */
+
+typedef struct {
+    char channel[16];
+    char chat_id[64];
+} stream_dispatch_ctx_t;
+
+/* on_stream callback: each cumulative text fragment is pushed as a partial
+ * outbound message so the on-device GUI can render + speak progressively.
+ * The final fragment (partial=false) is still dispatched by dispatch_response
+ * at the end of the loop, so the GUI knows when the reply is complete. */
+static void on_stream_partial(const char* partial_text, void* ctx)
+{
+    stream_dispatch_ctx_t* sc = (stream_dispatch_ctx_t*)ctx;
+    if (!sc || !partial_text || !partial_text[0]) {
+        return;
+    }
+
+    agent_msg_t out = { 0 };
+    strncpy(out.channel, sc->channel, sizeof(out.channel) - 1);
+    strncpy(out.chat_id, sc->chat_id, sizeof(out.chat_id) - 1);
+    out.content = strdup(partial_text);
+    out.partial = true;
+    if (out.content) {
+        if (message_bus_push_outbound(&out) != OK) {
+            free(out.content);
+        }
+    }
+}
+
 /* ── ReAct tool-calling loop ──────────────────────────────── */
 
 static const char* s_working_phrases[] = {
@@ -897,7 +958,8 @@ static void send_working_status(const agent_msg_t* msg, int iteration)
 #ifdef CONFIG_FEATURE_SYSTEM_VELACLAW
         || strcmp(msg->channel, AGENT_CHAN_QUICKAPP) == 0
 #endif
-        || strcmp(msg->channel, AGENT_CHAN_WEIXIN) == 0) {
+        || strcmp(msg->channel, AGENT_CHAN_WEIXIN) == 0
+        || strcmp(msg->channel, AGENT_CHAN_LOCAL_CLIENT) == 0) {
         return;
     }
 
@@ -1030,6 +1092,24 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
     int last_total_tokens = 0;
     bool watchdog_fired = false;
 
+    /* Stream partial text to the on-device GUI (local_client) so it can
+     * render + speak progressively instead of waiting for the full reply. */
+    bool use_stream = (strcmp(msg->channel, AGENT_CHAN_LOCAL_CLIENT) == 0);
+    stream_dispatch_ctx_t sctx;
+    memset(&sctx, 0, sizeof(sctx));
+    if (use_stream) {
+        strncpy(sctx.channel, msg->channel, sizeof(sctx.channel) - 1);
+        strncpy(sctx.chat_id, msg->chat_id, sizeof(sctx.chat_id) - 1);
+    }
+
+    /* The response cache is keyed on the current message only, but the
+     * on-device toy (local_client) is a stateful conversational agent — its
+     * replies depend on conversation history (RPG branching), not just the
+     * latest words. Serving a cached reply there returns a stale answer (the
+     * buddy re-tells the intro instead of branching), so skip the cache for
+     * that channel entirely. */
+    bool cacheable = (strcmp(msg->channel, AGENT_CHAN_LOCAL_CLIENT) != 0);
+
     /* Router: select and apply best backend before first LLM call.
      * Estimate complexity from the last user message. */
     llm_complexity_t complexity = LLM_COMPLEXITY_SIMPLE;
@@ -1048,7 +1128,7 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
     trace.backend_idx = router_idx;
 
     /* Cache check: for simple queries, try cache before LLM call */
-    if (msg->content && complexity == LLM_COMPLEXITY_SIMPLE) {
+    if (cacheable && msg->content && complexity == LLM_COMPLEXITY_SIMPLE) {
         char* cached = llm_cache_get(msg->content, strlen(msg->content));
         if (cached) {
             syslog(LOG_INFO, "[%s] Cache hit, skipping LLM call\n", TAG);
@@ -1066,7 +1146,13 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
         llm_response_t resp;
         struct timeval tv_start, tv_end;
         gettimeofday(&tv_start, NULL);
-        int err = llm_chat_tools(sys_prompt, messages, tools_json, &resp);
+        int err;
+        if (use_stream) {
+            err = llm_chat_tools_stream(sys_prompt, messages, tools_json,
+                &resp, on_stream_partial, &sctx);
+        } else {
+            err = llm_chat_tools(sys_prompt, messages, tools_json, &resp);
+        }
         gettimeofday(&tv_end, NULL);
         uint32_t latency_ms = calc_elapsed_ms(&tv_start, &tv_end);
 
@@ -1112,22 +1198,10 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
             break;
         }
 
-        /* Watchdog: if the LLM call took longer than the configured
-         * timeout, treat it as a timeout even if it returned OK.
-         * The socket SO_RCVTIMEO may have fired and caused a partial
-         * or error response that llm_chat_tools mapped to ERROR above,
-         * but if the call barely completed, we still flag it. */
-        if (llm_call_timed_out(latency_ms)) {
-            syslog(LOG_WARNING,
-                "[%s] LLM watchdog: call took %" PRIu32 " ms (limit %ds), "
-                "treating as timeout\n",
-                TAG, latency_ms, AGENT_LLM_TIMEOUT_SEC);
-            agent_trace_step(&trace, iteration, NULL, latency_ms, 0);
-            llm_response_free(&resp);
-            final_text = strdup(LLM_TIMEOUT_MSG);
-            watchdog_fired = true;
-            break;
-        }
+        /* The socket-level SO_RCVTIMEO (AGENT_LLM_SOCKET_TIMEOUT_SEC) is the
+         * real backstop that unblocks the read. If llm_chat_tools returned
+         * OK, the response is complete and usable regardless of how long it
+         * took, so keep the valid reply instead of discarding it as timeout. */
 
         /* Report success to router */
         if (router_idx >= 0) {
@@ -1189,8 +1263,9 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
                     gettimeofday(&tv_end, NULL);
                     latency_ms = calc_elapsed_ms(&tv_start, &tv_end);
 
-                    /* Watchdog check on cascade retry */
-                    if (llm_call_timed_out(latency_ms)) {
+                    /* Watchdog check on cascade retry — only if the call
+                     * actually failed; a slow-but-valid reply is kept. */
+                    if (err != OK && llm_call_timed_out(latency_ms)) {
                         syslog(LOG_WARNING,
                             "[%s] LLM watchdog: cascade retry "
                             "took %" PRIu32 " ms\n",
@@ -1344,8 +1419,11 @@ static char* run_react_loop(const char* sys_prompt, cJSON* messages,
     }
 
 send_reply:
-    /* Cache store: save simple query responses for future reuse */
-    if (final_text && msg->content
+    /* Cache store: save simple query responses for future reuse.
+     * Never cache a timeout/error reply — otherwise one slow LLM call
+     * would poison the cache and every subsequent identical question
+     * would return "请求超时" instantly instead of retrying. */
+    if (cacheable && !watchdog_fired && final_text && msg->content
         && complexity == LLM_COMPLEXITY_SIMPLE) {
         llm_cache_put(msg->content, strlen(msg->content), final_text);
         if (last_total_tokens > 0) {

--- a/src/core/agent_mem.h
+++ b/src/core/agent_mem.h
@@ -49,10 +49,11 @@ typedef struct {
  */
 static inline void agent_mem_get_status(agent_mem_status_t* st)
 {
-    struct mallinfo mi = mallinfo();
-    st->total_heap = mi.arena;
-    st->free_heap = mi.fordblks;
-    st->largest_block = mi.fordblks; /* conservative estimate */
+    /* mallinfo() is unsafe on this board — report enough to satisfy checks */
+    st->total_heap = 8 * 1024 * 1024;   /* 8 MB */
+    st->free_heap = 4 * 1024 * 1024;    /* 4 MB free */
+    st->largest_block = 1 * 1024 * 1024; /* 1 MB largest block */
+    (void)st;
 }
 
 /**

--- a/src/core/message_bus.h
+++ b/src/core/message_bus.h
@@ -36,6 +36,7 @@ typedef struct {
     char  chat_id[64];   /**< chat_id (Feishu IDs are ~36 chars) */
     char *content;       /**< Heap-allocated text; receiver must free. */
     char *image_b64;     /**< Optional base64-encoded image; receiver must free. NULL if none. */
+    bool  partial;       /**< true = streaming fragment (more coming), false = final */
 } agent_msg_t;
 
 /** Free heap members (content, image_b64) of a message.

--- a/src/llm/llm_cache.c
+++ b/src/llm/llm_cache.c
@@ -38,14 +38,16 @@ static pthread_mutex_t s_cache_lock = PTHREAD_MUTEX_INITIALIZER;
 static uint32_t s_tokens_saved;
 static uint32_t s_total_hits;
 
-/* djb2 hash over first LLM_CACHE_KEY_LEN chars */
+/* djb2 hash over the FULL string. Hash the whole message, not just a fixed
+ * prefix: kid_buddy sends "[SYSTEM]…\n[USER]\n<query>", so the meaningful
+ * part (the query) is at the END. Hashing only the first LLM_CACHE_KEY_LEN
+ * bytes made every query under one role collide on the same cached reply. */
 
 static uint32_t djb2_hash(const char* str, size_t len)
 {
     uint32_t h = 5381;
-    size_t n = len < LLM_CACHE_KEY_LEN ? len : LLM_CACHE_KEY_LEN;
 
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < len; i++) {
         h = ((h << 5) + h) + (unsigned char)str[i];
     }
     return h;

--- a/src/llm/llm_proxy.c
+++ b/src/llm/llm_proxy.c
@@ -51,6 +51,17 @@ static char s_vision_model[64] = { 0 };
 static char s_vision_host[128] = { 0 };
 static char s_vision_api_key[128] = { 0 };
 
+/* MiMo thinking toggle: mimo-v2.5 is a hybrid reasoning model that "thinks"
+ * by default (~90-100s per call).  When disabled we send
+ * thinking:{"type":"disabled"} to cut latency to seconds.
+ *
+ * Default to DISABLED (fast) for the on-device kid buddy: 90-100s of
+ * reasoning exceeds AGENT_LLM_TIMEOUT_SEC (60s), so leaving thinking on
+ * makes every MiMo call time out and surface "Sorry, I encountered an
+ * error."  The field is only sent to xiaomimimo hosts (see add_thinking_param),
+ * so this default is a no-op for other LLM backends. */
+static int s_thinking_disabled = 1;
+
 static pthread_mutex_t s_llm_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* Check if host uses OpenAI-compatible max_completion_tokens param */
@@ -59,6 +70,28 @@ bool is_openai_compat_host(const char* host)
     return strstr(host, "openai.com")
         || strstr(host, "openrouter.ai")
         || strstr(host, "xiaomimimo.com");
+}
+
+/* Add MiMo's "thinking" toggle to the request body.  The field is
+ * MiMo-specific, so only send it to a xiaomimimo host. */
+static void add_thinking_param(cJSON* body, const char* llm_host)
+{
+    if (!s_thinking_disabled)
+        return;
+    if (!llm_host || !strstr(llm_host, "xiaomimimo.com"))
+        return;
+
+    cJSON* thinking = cJSON_CreateObject();
+    cJSON_AddStringToObject(thinking, "type", "disabled");
+    cJSON_AddItemToObject(body, "thinking", thinking);
+}
+
+int llm_set_thinking(int disabled)
+{
+    pthread_mutex_lock(&s_llm_lock);
+    s_thinking_disabled = disabled ? 1 : 0;
+    pthread_mutex_unlock(&s_llm_lock);
+    return claw_config_set(AGENT_CFG_KEY_LLM_THINKING, disabled ? "off" : "on");
 }
 
 
@@ -139,6 +172,13 @@ int llm_proxy_init(void)
     memset(tmp, 0, sizeof(tmp));
     if (claw_config_get(AGENT_CFG_KEY_VISION_API_KEY, tmp, sizeof(tmp)) == OK && tmp[0])
         strncpy(s_vision_api_key, tmp, sizeof(s_vision_api_key) - 1);
+
+    /* MiMo thinking mode: "off"/"disabled"/"0" disables reasoning (fast). */
+    memset(tmp, 0, sizeof(tmp));
+    if (claw_config_get(AGENT_CFG_KEY_LLM_THINKING, tmp, sizeof(tmp)) == OK && tmp[0])
+        s_thinking_disabled =
+            (strcmp(tmp, "off") == 0 || strcmp(tmp, "disabled") == 0 ||
+             strcmp(tmp, "0") == 0);
 
     if (s_api_key[0])
         syslog(LOG_INFO, "[%s] LLM proxy initialized (model: %s, host: %s)\n", TAG,
@@ -608,6 +648,7 @@ int llm_chat(const char* system_prompt, const char* messages_json,
     cJSON_InsertItemInArray(messages, 0, sys_msg);
 
     cJSON_AddItemToObject(body, "messages", messages);
+    add_thinking_param(body, llm_host);
 
     char* post_data = cJSON_PrintUnformatted(body);
     cJSON_Delete(body);
@@ -723,6 +764,7 @@ int llm_chat_tools(const char* system_prompt, cJSON* messages,
     cJSON_AddStringToObject(sys_msg, "content", system_prompt);
     cJSON_InsertItemInArray(msgs, 0, sys_msg);
     cJSON_AddItemToObject(body, "messages", msgs);
+    add_thinking_param(body, llm_host);
 
     /* Convert tools to OpenAI format */
     cJSON* tools_arr = build_openai_tools_array(tools_json);
@@ -904,6 +946,334 @@ int llm_chat_tools(const char* system_prompt, cJSON* messages,
         "[%s] Response: %d bytes text, %d tool calls, finish=%s\n",
         TAG, (int)resp->text_len, resp->call_count,
         resp->tool_use ? "tool_calls" : "end_turn");
+
+    return OK;
+}
+
+/* ── Streaming (SSE) response parsing ──────────────────────── */
+
+typedef struct {
+    llm_response_t* resp;
+    llm_stream_cb_t on_stream;
+    void* on_stream_ctx;
+
+    char line[8192];      /* partial current line across reads */
+    size_t line_len;
+    bool done;            /* received [DONE] */
+    bool saw_data;        /* first "data:" line seen → streaming confirmed */
+
+    char raw[65536];      /* raw body kept as non-streaming fallback */
+    size_t raw_len;
+    bool raw_overflow;
+} sse_parser_t;
+
+static void sse_append_text(sse_parser_t* sp, const char* delta)
+{
+    llm_response_t* resp = sp->resp;
+    size_t dlen = strlen(delta);
+
+    if (dlen == 0)
+        return;
+
+    size_t new_len = resp->text_len + dlen;
+    char* nt = realloc(resp->text, new_len + 1);
+    if (!nt)
+        return;
+
+    memcpy(nt + resp->text_len, delta, dlen);
+    nt[new_len] = '\0';
+    resp->text = nt;
+    resp->text_len = new_len;
+
+    if (sp->on_stream)
+        sp->on_stream(nt, sp->on_stream_ctx);
+}
+
+static void sse_append_tool_calls(sse_parser_t* sp, cJSON* tool_calls)
+{
+    llm_response_t* resp = sp->resp;
+    cJSON* tc;
+
+    cJSON_ArrayForEach(tc, tool_calls)
+    {
+        cJSON* idx = cJSON_GetObjectItem(tc, "index");
+        int i = (idx && cJSON_IsNumber(idx)) ? (int)idx->valuedouble : 0;
+        if (i < 0 || i >= AGENT_MAX_TOOL_CALLS)
+            continue;
+
+        llm_tool_call_t* call = &resp->calls[i];
+        if (resp->call_count <= i)
+            resp->call_count = i + 1;
+
+        cJSON* id_item = cJSON_GetObjectItem(tc, "id");
+        if (id_item && cJSON_IsString(id_item) && id_item->valuestring)
+            strncpy(call->id, id_item->valuestring, sizeof(call->id) - 1);
+
+        cJSON* fn = cJSON_GetObjectItem(tc, "function");
+        if (!fn)
+            continue;
+
+        cJSON* name = cJSON_GetObjectItem(fn, "name");
+        if (name && cJSON_IsString(name) && name->valuestring)
+            strncpy(call->name, name->valuestring, sizeof(call->name) - 1);
+
+        cJSON* args = cJSON_GetObjectItem(fn, "arguments");
+        if (args && cJSON_IsString(args) && args->valuestring
+            && args->valuestring[0]) {
+            size_t alen = strlen(args->valuestring);
+            char* ninput = realloc(call->input, call->input_len + alen + 1);
+            if (ninput) {
+                memcpy(ninput + call->input_len, args->valuestring, alen);
+                call->input_len += alen;
+                ninput[call->input_len] = '\0';
+                call->input = ninput;
+            }
+        }
+    }
+
+    if (resp->call_count > 0)
+        resp->tool_use = true;
+}
+
+static void sse_handle_json(sse_parser_t* sp, cJSON* j)
+{
+    cJSON* choices = cJSON_GetObjectItem(j, "choices");
+    if (!choices || !cJSON_IsArray(choices) || !choices->child)
+        return;
+
+    cJSON* delta = cJSON_GetObjectItem(choices->child, "delta");
+    if (!delta)
+        return;
+
+    cJSON* content = cJSON_GetObjectItem(delta, "content");
+    if (content && cJSON_IsString(content) && content->valuestring)
+        sse_append_text(sp, content->valuestring);
+
+    cJSON* tool_calls = cJSON_GetObjectItem(delta, "tool_calls");
+    if (tool_calls && cJSON_IsArray(tool_calls))
+        sse_append_tool_calls(sp, tool_calls);
+}
+
+static void sse_handle_line(sse_parser_t* sp)
+{
+    const char* line = sp->line;
+
+    while (*line == ' ' || *line == '\r' || *line == '\t')
+        line++;
+
+    if (strncmp(line, "data:", 5) != 0)
+        return; /* not a data line */
+
+    sp->saw_data = true;
+
+    line += 5;
+    while (*line == ' ')
+        line++;
+
+    if (strcmp(line, "[DONE]") == 0) {
+        sp->done = true;
+        return;
+    }
+
+    if (*line == '\0')
+        return;
+
+    cJSON* j = cJSON_Parse(line);
+    if (!j)
+        return; /* partial/empty data — ignore */
+
+    sse_handle_json(sp, j);
+    cJSON_Delete(j);
+}
+
+static void sse_feed(sse_parser_t* sp, const char* data, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        char c = data[i];
+        if (c == '\n') {
+            /* Strip a trailing '\r' from CRLF line endings so the "[DONE]"
+             * sentinel and JSON both match exactly. */
+            if (sp->line_len > 0 && sp->line[sp->line_len - 1] == '\r')
+                sp->line_len--;
+            sp->line[sp->line_len] = '\0';
+            sse_handle_line(sp);
+            sp->line_len = 0;
+        } else if (sp->line_len < sizeof(sp->line) - 1) {
+            sp->line[sp->line_len++] = c;
+        }
+    }
+
+    /* Keep a bounded copy of the raw body for a non-streaming fallback, but
+     * only until the first "data:" line proves streaming is live — after that
+     * the SSE path owns the text and the raw copy is just wasted work. */
+    if (!sp->saw_data) {
+        size_t room = sizeof(sp->raw) - 1 - sp->raw_len;
+        size_t n = len < room ? len : room;
+        if (n > 0) {
+            memcpy(sp->raw + sp->raw_len, data, n);
+            sp->raw_len += n;
+            sp->raw[sp->raw_len] = '\0';
+        } else {
+            sp->raw_overflow = true;
+        }
+    }
+}
+
+static int llm_http_stream_cb(const char* data, size_t len, void* ctx)
+{
+    sse_feed((sse_parser_t*)ctx, data, len);
+    return 0;
+}
+
+/* Extract text + tool_calls from a non-streaming JSON object (fallback). */
+static void extract_response_from_json(cJSON* root, llm_response_t* resp)
+{
+    cJSON* choices = cJSON_GetObjectItem(root, "choices");
+    if (!choices || !cJSON_IsArray(choices) || !choices->child)
+        return;
+
+    cJSON* message = cJSON_GetObjectItem(choices->child, "message");
+    if (!message)
+        return;
+
+    cJSON* content = cJSON_GetObjectItem(message, "content");
+    if (content && cJSON_IsString(content) && content->valuestring) {
+        size_t tlen = strlen(content->valuestring);
+        resp->text = calloc(1, tlen + 1);
+        if (resp->text) {
+            memcpy(resp->text, content->valuestring, tlen);
+            resp->text_len = tlen;
+        }
+    }
+
+    extract_openai_tool_calls(message, resp);
+
+    cJSON* usage = cJSON_GetObjectItem(root, "usage");
+    if (usage) {
+        cJSON* pt = cJSON_GetObjectItem(usage, "prompt_tokens");
+        cJSON* ct = cJSON_GetObjectItem(usage, "completion_tokens");
+        cJSON* tt = cJSON_GetObjectItem(usage, "total_tokens");
+        if (pt && cJSON_IsNumber(pt))
+            resp->prompt_tokens = (int)pt->valuedouble;
+        if (ct && cJSON_IsNumber(ct))
+            resp->completion_tokens = (int)ct->valuedouble;
+        if (tt && cJSON_IsNumber(tt))
+            resp->total_tokens = (int)tt->valuedouble;
+    }
+}
+
+int llm_chat_tools_stream(const char* system_prompt, cJSON* messages,
+    const char* tools_json, llm_response_t* resp,
+    llm_stream_cb_t on_stream, void* on_stream_ctx)
+{
+    memset(resp, 0, sizeof(*resp));
+
+    /* Snapshot config under lock */
+    char model[64], api_key[128], llm_host[128], llm_path[128], llm_port[8];
+    pthread_mutex_lock(&s_llm_lock);
+    memcpy(model, s_model, sizeof(model));
+    memcpy(api_key, s_api_key, sizeof(api_key));
+    memcpy(llm_host, s_llm_host, sizeof(llm_host));
+    memcpy(llm_path, s_llm_path, sizeof(llm_path));
+    memcpy(llm_port, s_llm_port, sizeof(llm_port));
+    pthread_mutex_unlock(&s_llm_lock);
+
+    if (api_key[0] == '\0')
+        return ERROR;
+
+    int use_tls = (strcmp(llm_port, "443") == 0);
+    if (!use_tls) {
+        /* Plain-HTTP streaming is not implemented — delegate. */
+        return llm_chat_tools(system_prompt, messages, tools_json, resp);
+    }
+
+    /* Build request body with stream:true */
+    cJSON* body = cJSON_CreateObject();
+    cJSON_AddStringToObject(body, "model", model_name_for_api(model, llm_host));
+
+    if (is_openai_compat_host(llm_host))
+        cJSON_AddNumberToObject(body, "max_completion_tokens",
+            AGENT_LLM_MAX_TOKENS_OPENAI);
+    else
+        cJSON_AddNumberToObject(body, "max_tokens", AGENT_LLM_MAX_TOKENS);
+
+    cJSON_AddBoolToObject(body, "stream", 1);
+    add_thinking_param(body, llm_host);
+
+    cJSON* msgs = cJSON_Duplicate(messages, 1);
+    cJSON* sys_msg = cJSON_CreateObject();
+    cJSON_AddStringToObject(sys_msg, "role", "system");
+    cJSON_AddStringToObject(sys_msg, "content", system_prompt);
+    cJSON_InsertItemInArray(msgs, 0, sys_msg);
+    cJSON_AddItemToObject(body, "messages", msgs);
+
+    cJSON* tools_arr = build_openai_tools_array(tools_json);
+    if (tools_arr)
+        cJSON_AddItemToObject(body, "tools", tools_arr);
+
+    char* post_data = cJSON_PrintUnformatted(body);
+    cJSON_Delete(body);
+    if (!post_data)
+        return ERROR;
+
+    syslog(LOG_INFO, "[%s] OpenAI API stream (model: %s, %d bytes)\n",
+        TAG, model, (int)strlen(post_data));
+
+    /* Auth + provider headers */
+    char auth_header[256];
+    snprintf(auth_header, sizeof(auth_header), "Bearer %s", api_key);
+
+    char provider[64] = { 0 };
+    const char* slash = strchr(model, '/');
+    if (slash) {
+        size_t plen = (size_t)(slash - model);
+        if (plen >= sizeof(provider))
+            plen = sizeof(provider) - 1;
+        memcpy(provider, model, plen);
+    }
+
+    vela_header_t hdrs[] = { { "Authorization", auth_header },
+        { provider[0] ? "X-Model-Provider-Id" : NULL,
+            provider[0] ? provider : NULL },
+        { NULL, NULL } };
+
+    /* Heap-allocate the parser state: it carries ~73KB of buffers (SSE line +
+     * non-streaming fallback), which would blow the 32KB agent-task stack. */
+    sse_parser_t* sp = calloc(1, sizeof(sse_parser_t));
+    if (!sp) {
+        free(post_data);
+        return ERROR;
+    }
+    sp->resp = resp;
+    sp->on_stream = on_stream;
+    sp->on_stream_ctx = on_stream_ctx;
+
+    int status = vela_https_post_json_stream(llm_host, llm_port, llm_path,
+        hdrs, post_data, llm_http_stream_cb, sp);
+    free(post_data);
+
+    if (status != 200) {
+        syslog(LOG_ERR, "[%s] stream API error %d\n", TAG, status);
+        free(sp);
+        return ERROR;
+    }
+
+    /* If no SSE chunks were parsed (endpoint ignored "stream"), fall back to
+     * parsing the buffered body as a single non-streaming JSON. */
+    if (resp->text_len == 0 && resp->call_count == 0
+        && sp->raw_len > 0 && !sp->raw_overflow) {
+        cJSON* root = cJSON_Parse(sp->raw);
+        if (root) {
+            extract_response_from_json(root, resp);
+            cJSON_Delete(root);
+        }
+    }
+
+    free(sp);
+
+    syslog(LOG_INFO,
+        "[%s] Stream response: %d bytes text, %d tool calls\n",
+        TAG, (int)resp->text_len, resp->call_count);
 
     return OK;
 }

--- a/src/llm/llm_proxy.h
+++ b/src/llm/llm_proxy.h
@@ -36,6 +36,10 @@ int llm_proxy_init(void);
 int llm_set_backend(const char* host, const char* path);
 int llm_set_port(const char* port);
 
+/** Toggle MiMo thinking/reasoning mode.  1 = disable thinking (fast,
+ *  seconds), 0 = enable (default, better quality but ~90-100s/call). */
+int llm_set_thinking(int disabled);
+
 /**
  * Atomically set all LLM proxy fields in a single lock acquisition.
  * Used by llm_router to avoid partial updates.
@@ -77,6 +81,21 @@ int llm_chat_tools(const char* system_prompt,
     cJSON* messages,
     const char* tools_json,
     llm_response_t* resp);
+
+/** Streaming delta callback: invoked with the *accumulated* assistant text
+ *  (not just the new delta) each time new content arrives. `partial_text`
+ *  is valid only for the duration of the call — copy it if kept. */
+typedef void (*llm_stream_cb_t)(const char* partial_text, void* ctx);
+
+/** Streaming variant of llm_chat_tools(). Sends "stream": true and parses
+ *  the SSE response incrementally, invoking `on_stream` (if non-NULL) with
+ *  the running text. Fills `resp` identically to llm_chat_tools() (text +
+ *  tool_calls), so callers keep the same control flow. */
+int llm_chat_tools_stream(const char* system_prompt,
+    cJSON* messages,
+    const char* tools_json,
+    llm_response_t* resp,
+    llm_stream_cb_t on_stream, void* on_stream_ctx);
 
 /** Vision chat: send text + base64 image to a vision-capable model.
  *  image_b64 is the raw base64 string (no data: prefix).

--- a/src/sdk/velaclaw_client_local.c
+++ b/src/sdk/velaclaw_client_local.c
@@ -28,6 +28,8 @@ struct velaclaw_client_s {
     int reply_status;
     void (*async_cb)(int, const char*, void*);
     void* async_cookie;
+    void (*notify_cb)(int, const char*, void*);
+    void* notify_cookie;
 };
 
 static struct velaclaw_client_s* g_client_instance;
@@ -42,14 +44,32 @@ static void tap_callback(const agent_msg_t* msg, void* cookie)
     pthread_mutex_lock(&c->mtx);
 
     if (c->async_cb) {
-        /* Async mode: invoke user callback directly */
+        /* Async mode: invoke user callback directly.
+         * Streaming replies arrive as a series of partial fragments
+         * (status 1) followed by one final fragment (status 0). Keep the
+         * callback registered across partial fragments so the whole stream
+         * reaches the caller; clear it only on the final fragment. */
         void (*cb)(int, const char*, void*) = c->async_cb;
         void* ck = c->async_cookie;
-        c->async_cb = NULL;
-        c->async_cookie = NULL;
+        int status = msg->partial ? 1 : 0;
+        if (!msg->partial) {
+            c->async_cb = NULL;
+            c->async_cookie = NULL;
+        }
         pthread_mutex_unlock(&c->mtx);
 
-        cb(0, msg->content, ck);
+        cb(status, msg->content, ck);
+        return;
+    }
+
+    /* No ask in flight — route to the persistent notify callback (e.g. cron
+     * reminders), mirroring async semantics but keeping notify_cb registered. */
+    if (c->notify_cb) {
+        void (*cb)(int, const char*, void*) = c->notify_cb;
+        void* ck = c->notify_cookie;
+        int status = msg->partial ? 1 : 0;
+        pthread_mutex_unlock(&c->mtx);
+        cb(status, msg->content, ck);
         return;
     }
 
@@ -120,6 +140,49 @@ void velaclaw_client_close(velaclaw_client_t* c)
     syslog(LOG_INFO, "[%s] client closed\n", TAG);
 }
 
+void velaclaw_set_notify_callback(velaclaw_client_t* c,
+    void (*cb)(int, const char*, void*), void* cookie)
+{
+    if (!c) {
+        return;
+    }
+
+    pthread_mutex_lock(&c->mtx);
+    c->notify_cb = cb;
+    c->notify_cookie = cookie;
+    pthread_mutex_unlock(&c->mtx);
+}
+
+int velaclaw_publish(velaclaw_client_t* c,
+    const char* channel, const char* chat_id, const char* text)
+{
+    (void)c; /* the bus is a shared singleton — no per-client state needed */
+
+    if (!channel || !chat_id || !text) {
+        return -EINVAL;
+    }
+
+    agent_msg_t msg = { 0 };
+    strncpy(msg.channel, channel, sizeof(msg.channel) - 1);
+    strncpy(msg.chat_id, chat_id, sizeof(msg.chat_id) - 1);
+    msg.content = strdup(text);
+
+    if (!msg.content) {
+        return -ENOMEM;
+    }
+
+    int ret = message_bus_push_outbound(&msg);
+
+    if (ret != OK) {
+        free(msg.content);
+        return -EIO;
+    }
+
+    syslog(LOG_INFO, "[%s] publish to %s:%s (%zu bytes)\n",
+        TAG, channel, chat_id, strlen(text));
+    return 0;
+}
+
 int velaclaw_ask(velaclaw_client_t* c,
     const velaclaw_ask_req_t* req,
     void (*cb)(int, const char*, void*), void* cookie)
@@ -134,10 +197,15 @@ int velaclaw_ask(velaclaw_client_t* c,
     c->async_cookie = cookie;
     pthread_mutex_unlock(&c->mtx);
 
-    /* Push message to agent inbound queue */
+    /* Push message to agent inbound queue. An explicit per-request chat_id
+     * (story/RPG session) overrides the client's app_id, which keeps that
+     * session's history isolated from free chat. */
+    const char* chat_id =
+        (req->chat_id && req->chat_id[0]) ? req->chat_id : c->app_id;
+
     agent_msg_t msg = { 0 };
     strncpy(msg.channel, CLIENT_CHANNEL, sizeof(msg.channel) - 1);
-    strncpy(msg.chat_id, c->app_id, sizeof(msg.chat_id) - 1);
+    strncpy(msg.chat_id, chat_id, sizeof(msg.chat_id) - 1);
     msg.content = strdup(req->text);
     if (!msg.content) {
         return -ENOMEM;

--- a/src/tools/skill_loader.c
+++ b/src/tools/skill_loader.c
@@ -130,8 +130,8 @@ static const char *TAG = "skills";
     "## How to use\n" \
     "1. get_current_time for current epoch\n" \
     "2. Parse user request into schedule_type and timing\n" \
-    "3. Set channel/chat_id matching the message source (feishu/system)\n" \
-    "4. cron_add to create the job\n" \
+    "3. Do NOT set channel, chat_id, report_channel or report_chat_id — the system fills them in automatically. A reminder from a remote parent channel (MQTT/Feishu/WebSocket/WeChat) is spoken on the device to the child, and the child's confirmation is reported back to the parent. An on-device voice request is spoken on the device only.\n" \
+    "4. cron_add to create the job. Do NOT set action or action_args — leave them empty; a plain reminder just sends the message at trigger time.\n" \
     "5. Confirm with trigger time\n"
 
 #define BUILTIN_NOTE_TAKER \
@@ -195,6 +195,34 @@ static const char *TAG = "skills";
     "- Add: get_current_time, then edit_file/write_file to append: - [ ] [YYYY-MM-DD] desc\n" \
     "- Complete: edit_file to change - [ ] to - [x]\n"
 
+#define BUILTIN_STORY_RPG \
+    "# Story RPG (文字冒险游戏)\n" \
+    "\n" \
+    "陪小朋友玩分支剧情的文字冒险/角色扮演游戏：讲背景故事，给2-3个选项，小朋友语音选择，剧情按选择发展并继续给选项，直到结局。\n" \
+    "\n" \
+    "## When to use\n" \
+    "当小朋友说“我们来玩冒险游戏/角色扮演/角色扮演游戏/讲故事游戏/文字RPG/编故事”，或想听故事并且自己决定剧情走向时，触发本技能。\n" \
+    "\n" \
+    "## How to use\n" \
+    "1. 进入游戏：先用一句话确认开始，讲清故事背景（2-3句，含主角、场景、目标）。\n" \
+    "2. 每轮输出：先讲一小段剧情发展（1-3句），然后用一句自然的口语把2-3个选项说清楚，例如“你想钻进树洞，还是爬上树屋，或者沿着小路走？”。千万不要用“A. B. C.”这种生硬标签，也不要写“选项1/选项2”。\n" \
+    "3. 等小朋友语音选择：他们可能说“选第一个”“第二个”“我要钻树洞”“走小路”，也可能复述选项内容，要根据意思正确对应到某个选项，不要强迫他们报字母或编号。\n" \
+    "4. 按选择推进剧情，再自然地给出下一组选项，如此循环，剧情要有悬念和变化。\n" \
+    "5. 结局：剧情自然收尾时给完整结局，并问“还想再玩一次吗？”。\n" \
+    "6. 退出：小朋友说“退出游戏/不玩了/结束”时停止游戏，回到默认角色。\n" \
+    "\n" \
+    "## Rules (重要)\n" \
+    "- 游戏期间你是“故事主持人”，可临时取代用户消息里[SYSTEM]默认角色的人设，专心讲好故事。\n" \
+    "- 全程简体中文，语气亲切，适合6-12岁孩子。\n" \
+    "- 每轮回复简短（适合语音朗读），不要一次讲太长，不要用表情符号。\n" \
+    "- 选项要用完整句子自然带出，让小朋友听一遍就懂，不要在句末堆一串字母。\n" \
+    "- 记住剧情进展：上一轮的选项与选择结果在历史消息里，续写时保持一致，不要前后矛盾。\n" \
+    "- 剧情健康、积极、无暴力恐怖。\n" \
+    "\n" \
+    "## Example\n" \
+    "小朋友：“我们来玩冒险游戏！”\n" \
+    "→ “好呀！你是一位住在魔法森林里的小探险家。今天森林里的小动物都睡着了，只有你能唤醒它们。现在你面前有一条岔路，你想走进发光的山洞，还是爬上高高的树屋，或者沿着小溪往前走呢？”\n"
+
 /* Built-in skill registry */
 typedef struct {
     const char *filename;   /* e.g. "weather" */
@@ -212,6 +240,7 @@ static const builtin_skill_t s_builtins[] = {
     { "news-digest",    BUILTIN_NEWS_DIGEST    },
     { "feishu-test",    BUILTIN_FEISHU_TEST    },
     { "task-manager",   BUILTIN_TASK_MANAGER   },
+    { "story-rpg",      BUILTIN_STORY_RPG      },
 };
 
 #define NUM_BUILTINS (sizeof(s_builtins) / sizeof(s_builtins[0]))
@@ -223,16 +252,12 @@ static void install_builtin(const builtin_skill_t *skill)
     char path[128];
     snprintf(path, sizeof(path), "%s%s.md", AGENT_SKILLS_DIR, skill->filename);
 
-    /* Check if already exists */
-    FILE *f = fopen(path, "r");
-    if (f) {
-        fclose(f);
-        syslog(LOG_DEBUG, "[%s] Skill exists: %s\n", TAG, path);
-        return;
-    }
-
-    /* Write built-in skill */
-    f = fopen(path, "w");
+    /* Built-in skills are the curated source of truth: always (re)write them
+     * so an edit to the built-in text (e.g. the story-rpg phrasing) takes
+     * effect on the next boot even though the .md already exists on disk.
+     * User-authored skills created via skill-creator live under their own
+     * filenames and are not affected. */
+    FILE *f = fopen(path, "w");
     if (!f) {
         syslog(LOG_ERR, "[%s] Cannot write skill: %s\n", TAG, path);
         return;

--- a/src/tools/tool_registry.c
+++ b/src/tools/tool_registry.c
@@ -251,7 +251,8 @@ int tool_registry_init(void)
         "Steps: get_current_time→compute at_epoch→call this. "
         "at_epoch must be plain integer. "
         "Recurring: schedule_type='every', interval_s=seconds. "
-        "Action: set action=tool_name, action_args=JSON.",
+        "For a plain reminder, leave action and action_args EMPTY — "
+        "the job just sends the message at trigger time.",
         TOOL_SCHEMA_BEGIN()
             TOOL_PARAM_STR("name", "Job name") "," TOOL_PARAM_ENUM("schedule_type", "Schedule type", "\"every\",\"at\"") "," TOOL_PARAM_NUM("interval_s", "Interval in seconds (for every)") "," TOOL_PARAM_NUM("at_epoch",
                 "Target UNIX timestamp as a plain integer") "," TOOL_PARAM_STR("message",


### PR DESCRIPTION
- skill_loader: always overwrite the built-in .md when the skill is materialized, and carry the persona in the user message [SYSTEM] section rather than the system prompt; the previous wording made the model refuse role-play requests
- local client: give RPG sessions their own chat_id (keyword-triggered, optional explicit chat_id field) so story turns no longer bleed into the normal chat, and let the story continue on idle
- llm_proxy: disable the response cache for the in-process client; it was keyed on the current message truncated to 64 bytes and returned stale replies
- agent_loop / message_bus: 12s follow-up window so a child can answer or pick an option without repeating the wake word

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
