### PR TITLE
channels: single-instance agent, MQTT child reports, CLI guards

### DIFF
--- a/include/agent_config.h
+++ b/include/agent_config.h
@@ -249,6 +249,7 @@
 #define AGENT_CFG_KEY_FEISHU_USER_TOKEN "feishu_user_token"
 #define AGENT_CFG_KEY_LLM_HOST "llm_host"
 #define AGENT_CFG_KEY_LLM_PATH "llm_path"
+#define AGENT_CFG_KEY_LLM_THINKING "llm_thinking"
 #define AGENT_CFG_KEY_VISION_MODEL "vision_model"
 #define AGENT_CFG_KEY_VISION_HOST "vision_host"
 #define AGENT_CFG_KEY_VISION_API_KEY "vision_api_key"
@@ -293,6 +294,7 @@
 #define AGENT_CHAN_FEISHU "feishu"
 #define AGENT_CHAN_MQTT "mqtt"
 #define AGENT_CHAN_WEIXIN "weixin"
+#define AGENT_CHAN_LOCAL_CLIENT "local_client"
 #ifdef CONFIG_FEATURE_SYSTEM_VELACLAW
 #define AGENT_CHAN_QUICKAPP "quickapp"
 #endif

--- a/src/agent_main.c
+++ b/src/agent_main.c
@@ -92,9 +92,21 @@ static const char* TAG = "agent";
 pthread_mutex_t g_stdout_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* ── Global shutdown flag ─────────────────────────────────────── */
-/* Set by cmd_quit via agent_request_shutdown(); checked by main loop
- * to trigger graceful teardown instead of calling exit(). */
+/* Set via agent_request_shutdown() (e.g. by the app framework when the
+ * quickapp is killed); checked by the main loop to trigger graceful
+ * teardown instead of calling exit(). The interactive CLI's "quit" no
+ * longer sets this — it uses nsh_cli_done() so a config-only instance
+ * does not tear down the boot-time agent. */
 static volatile bool g_shutdown_requested = false;
+
+/* ── Double-start guard ──────────────────────────────────────── */
+/* In a FLAT build every spawn of "ai_agent" shares these statics, so this
+ * detects the boot-time "ai_agent --no-cli &" instance. A second foreground
+ * "ai_agent" (typed manually to reach the set_wifi/set_llm CLI) must NOT
+ * re-run init — that would spawn a second outbound dispatcher + agent loop
+ * fighting over the shared message bus. The second instance only attaches
+ * the interactive CLI and returns without tearing anything down. */
+static bool s_agent_started = false;
 
 void agent_request_shutdown(void)
 {
@@ -466,8 +478,35 @@ static inline long boot_ms(struct timespec* t0)
 
 int ai_agent_main(int argc, char* argv[])
 {
-    (void)argc;
-    (void)argv;
+    /* Parse args: --no-cli / --daemon disables the interactive CLI thread,
+     * used when auto-started in background so it does not compete with NSH
+     * for stdin. NOTE: must be a LOCAL (stack) variable, not static — in a
+     * FLAT build a static would be shared across every spawn of this app, so
+     * the boot-time "ai_agent --no-cli &" would permanently disable the CLI
+     * for any later foreground "ai_agent". */
+    bool cli_enabled = true;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--no-cli") == 0 ||
+            strcmp(argv[i], "--daemon") == 0) {
+            cli_enabled = false;
+        }
+    }
+
+    /* Already running (the boot-time background instance)? Attach the CLI
+     * only and block until the user quits — do NOT re-init, and do NOT run
+     * teardown (the original instance owns every service). */
+    if (s_agent_started) {
+        syslog(LOG_INFO, "[%s] ai_agent already running — %s\n", TAG,
+            cli_enabled ? "attaching CLI only" : "ignoring duplicate start");
+        if (cli_enabled) {
+            nsh_commands_start();
+            while (!nsh_cli_done()) {
+                sleep(1);
+            }
+        }
+        return 0;
+    }
+    s_agent_started = true;
 
     g_shutdown_requested = false;
 
@@ -503,12 +542,14 @@ int ai_agent_main(int argc, char* argv[])
     mkdir("/data/agent/skills", 0755);
     BOOT_LOG(&t0, "P0", "storage ready");
 
-    /* Memory info */
+    /* Memory info — disabled: mallinfo() may crash on fragmented heap */
+#if 0
     {
         struct mallinfo mi = mallinfo();
         syslog(LOG_INFO, "[%s] [boot +%ldms] heap: arena=%d free=%d used=%d\n",
             TAG, boot_ms(&t0), mi.arena, mi.fordblks, mi.uordblks);
     }
+#endif
 
     /* ── Phase 1: Core infrastructure ──────────────────────── */
     {
@@ -692,16 +733,25 @@ int ai_agent_main(int argc, char* argv[])
     BOOT_LOG(&t0, "P5", "network_watch thread started (async)");
 
     /* ── Phase 6: CLI thread — all services now in known state ── */
-    {
+    if (cli_enabled) {
         int rc = nsh_commands_start();
         BOOT_LOG_RC(&t0, "P6", "nsh_commands_start", rc);
+    } else {
+        syslog(LOG_INFO, "[%s] daemon mode (--no-cli): interactive CLI disabled\n",
+            TAG);
     }
 
     syslog(LOG_INFO, "[%s] [boot +%ldms] AI Agent ready. Type 'help' in NSH for commands.\n",
         TAG, boot_ms(&t0));
 
-    /* Block main thread until shutdown is requested */
+    /* Block main thread until shutdown is requested, or — in interactive
+     * (CLI) mode — until the user types "quit". The "quit" path only ends
+     * the CLI, it does not set g_shutdown_requested, so a config-only
+     * second instance can leave the boot-time agent untouched. */
     while (!g_shutdown_requested) {
+        if (cli_enabled && nsh_cli_done()) {
+            break;
+        }
         sleep(1);
     }
 

--- a/src/channels/cmd_voice.c
+++ b/src/channels/cmd_voice.c
@@ -130,3 +130,24 @@ void cmd_set_voice_asr(int argc, char** argv)
         printf("ASR backend '%s' not found.\n", argv[1]);
     }
 }
+
+void cmd_speak(int argc, char** argv)
+{
+    if (argc < 2) {
+        printf("Usage: speak <text>\n");
+        return;
+    }
+
+    /* Concatenate all arguments as the text to speak. */
+    char content[512] = { 0 };
+
+    for (int i = 1; i < argc; i++) {
+        strncat(content, argv[i], sizeof(content) - strlen(content) - 1);
+        if (i < argc - 1)
+            strncat(content, " ", sizeof(content) - strlen(content) - 1);
+    }
+
+    printf("Speaking: %s\n", content);
+    int ret = voice_channel_speak(content);
+    printf("speak done: %d\n", ret);
+}

--- a/src/channels/cmd_voice.h
+++ b/src/channels/cmd_voice.h
@@ -25,3 +25,4 @@ void cmd_voice_test_tts(int argc, char** argv);
 void cmd_voice_test_asr(int argc, char** argv);
 void cmd_set_voice_tts(int argc, char** argv);
 void cmd_set_voice_asr(int argc, char** argv);
+void cmd_speak(int argc, char** argv);

--- a/src/channels/mqtt_channel.c
+++ b/src/channels/mqtt_channel.c
@@ -33,8 +33,17 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/select.h>
 
 static const char *TAG = "mqtt";
+
+/* Bounded timeout for the TCP connect in tcp_connect(). A blocking
+ * connect() can stall for tens of seconds on an unreachable broker;
+ * on_reconnect() runs while holding s_client.mutex, so a long stall there
+ * also blocks the outbound dispatch task (mqtt_publish waits on the same
+ * mutex). Keep it short enough to avoid stalling dispatch. */
+#define MQTT_TCP_CONNECT_TIMEOUT_MS 5000
 
 /* ── Configuration ─────────────────────────────────────────── */
 
@@ -53,12 +62,16 @@ static uint8_t s_sendbuf[AGENT_MQTT_BUF_SIZE] __attribute__((aligned(4)));
 static uint8_t s_recvbuf[AGENT_MQTT_BUF_SIZE];
 static int     s_sockfd = -1;
 static volatile bool s_running;
+static volatile bool s_sync_thread_exited = true;
+static bool s_client_inited = false;
 
 /* ── TCP connect helper ────────────────────────────────────── */
 
 static int tcp_connect(const char *host, int port)
 {
     char port_str[8];
+    int fd;
+    int flags;
 
     snprintf(port_str, sizeof(port_str), "%d", port);
 
@@ -74,14 +87,20 @@ static int tcp_connect(const char *host, int port)
         return -1;
     }
 
-    int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 
     if (fd < 0) {
         freeaddrinfo(res);
         return -1;
     }
 
-    if (connect(fd, res->ai_addr, res->ai_addrlen) < 0) {
+    /* Non-blocking connect with a bounded timeout (see the comment on
+     * MQTT_TCP_CONNECT_TIMEOUT_MS for why this matters). */
+    flags = fcntl(fd, F_GETFL, 0);
+    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+    if (connect(fd, res->ai_addr, res->ai_addrlen) != 0
+        && errno != EINPROGRESS) {
         syslog(LOG_ERR, "[%s] TCP connect failed: %s:%d (%s)\n",
                TAG, host, port, strerror(errno));
         close(fd);
@@ -91,15 +110,55 @@ static int tcp_connect(const char *host, int port)
 
     freeaddrinfo(res);
 
-    /* Set recv timeout so mqtt_sync is not blocked forever.
-     * This allows MQTT-C to send PINGREQ on time. */
-    struct timeval tv;
+    fd_set wfds;
+    FD_ZERO(&wfds);
+    FD_SET(fd, &wfds);
+    struct timeval tv = {
+        .tv_sec = MQTT_TCP_CONNECT_TIMEOUT_MS / 1000,
+        .tv_usec = (MQTT_TCP_CONNECT_TIMEOUT_MS % 1000) * 1000
+    };
 
-    tv.tv_sec = 1;
-    tv.tv_usec = 0;
-    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    if (select(fd + 1, NULL, &wfds, NULL, &tv) <= 0) {
+        syslog(LOG_ERR, "[%s] TCP connect timeout: %s:%d\n",
+               TAG, host, port);
+        close(fd);
+        return -1;
+    }
 
-    syslog(LOG_INFO, "[%s] TCP connected to %s:%d (fd=%d)\n",
+    int sock_err = 0;
+    socklen_t sock_errlen = sizeof(sock_err);
+
+    getsockopt(fd, SOL_SOCKET, SO_ERROR, &sock_err, &sock_errlen);
+    if (sock_err != 0) {
+        syslog(LOG_ERR, "[%s] TCP connect failed: %s:%d (%s)\n",
+               TAG, host, port, strerror(sock_err));
+        close(fd);
+        return -1;
+    }
+
+    /* Keep the socket NON-BLOCKING for subsequent send/recv.
+     *
+     * This is the actual fix for the reminder being silent: MQTT-C's
+     * mqtt_pal_recvall()/mqtt_pal_sendall() are written for non-blocking
+     * sockets (EAGAIN == "nothing to do"), and mqtt_sync's usleep() paces the
+     * loop. A *blocking* recv() here blocks while holding client->mutex inside
+     * __mqtt_recv(), which both starves mqtt_publish() on the outbound
+     * dispatch thread AND stops __mqtt_send() from ever flushing the queue
+     * (the sync thread never reaches __mqtt_send while stuck in recv). On a
+     * flaky WiFi (half-dead TCP, no FIN/RST) SO_RCVTIMEO does not even fire,
+     * so the block is effectively forever. Non-blocking recv() always returns
+     * EAGAIN immediately. */
+    /* (leave fd in O_NONBLOCK from the connect above) */
+
+    /* Keep SO_RCVTIMEO as a fallback in case the stack ignores O_NONBLOCK on
+     * recv — worst case it bounds the block to 1s. */
+    struct timeval tv_rcv;
+
+    tv_rcv.tv_sec = 1;
+    tv_rcv.tv_usec = 0;
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv_rcv, sizeof(tv_rcv));
+
+    syslog(LOG_INFO, "[%s] TCP connected to %s:%d (fd=%d, non-blocking)\n",
            TAG, host, port, fd);
     return fd;
 }
@@ -241,6 +300,7 @@ static void *mqtt_sync_thread(void *arg)
         usleep(AGENT_MQTT_SYNC_INTERVAL_MS * 1000);
     }
 
+    s_sync_thread_exited = true;
     syslog(LOG_INFO, "[%s] Sync thread exited\n", TAG);
     return NULL;
 }
@@ -338,10 +398,35 @@ int mqtt_channel_start(void)
         return OK;
     }
 
-    /* Use mqtt_init_reconnect so MQTT-C handles auto-reconnect */
-    mqtt_init_reconnect(&s_client, on_reconnect, NULL, on_publish);
+    /* Idempotent: if a sync thread is already running, don't start another.
+     * Two threads sharing one s_client + the same client_id will CONNECT
+     * twice and the broker keeps kicking one off → endless reconnect loop. */
+    if (s_running) {
+        syslog(LOG_INFO, "[%s] MQTT already running, skip duplicate start\n",
+               TAG);
+        return OK;
+    }
+
+    /* Initialize the MQTT-C client exactly once. mqtt_init_reconnect()
+     * re-initializes s_client.mutex every call; re-initing a mutex that
+     * another thread (outbound dispatch via mqtt_publish, or a still-stuck
+     * old sync thread) may be blocked on is undefined behavior and can leave
+     * that thread permanently blocked. On re-start we soft-reset instead. */
+    if (!s_client_inited) {
+        mqtt_init_reconnect(&s_client, on_reconnect, NULL, on_publish);
+        s_client_inited = true;
+    } else {
+        mqtt_reinit(&s_client, -1,
+                    s_sendbuf, sizeof(s_sendbuf),
+                    s_recvbuf, sizeof(s_recvbuf));
+        /* mqtt_reinit leaves reconnect_callback/publish_response_callback
+         * intact from the first init; only reset the error so the first
+         * mqtt_sync triggers on_reconnect. */
+        s_client.error = MQTT_ERROR_INITIAL_RECONNECT;
+    }
 
     s_running = true;
+    s_sync_thread_exited = false;
 
     int ret = agent_task_create(mqtt_sync_thread, "mqtt_sync",
                                    AGENT_MQTT_STACK, NULL,
@@ -349,6 +434,7 @@ int mqtt_channel_start(void)
     if (ret != OK) {
         syslog(LOG_ERR, "[%s] Failed to create sync thread\n", TAG);
         s_running = false;
+        s_sync_thread_exited = true;
         return ERROR;
     }
 
@@ -406,8 +492,14 @@ void mqtt_channel_stop(void)
         s_sockfd = -1;
     }
 
-    /* Give sync thread time to notice s_running=false and exit */
-    usleep(AGENT_MQTT_SYNC_INTERVAL_MS * 2 * 1000);
+    /* Wait for the sync thread to actually exit before returning. Without
+     * this, a fast stop→start (e.g. `set_mqtt`) leaves the old thread alive:
+     * start() flips s_running back to true and creates a second thread, and
+     * the two threads CONNECT with the same client_id → the broker keeps
+     * kicking one off → endless reconnect loop (MQTT_ERROR_SOCKET_ERROR). */
+    for (int i = 0; i < 20 && !s_sync_thread_exited; i++) {
+        usleep(100 * 1000);
+    }
 
     syslog(LOG_INFO, "[%s] MQTT channel stopped\n", TAG);
 }

--- a/src/channels/nsh_commands.c
+++ b/src/channels/nsh_commands.c
@@ -74,6 +74,17 @@ static const char* TAG = "cli";
 #define MAX_ARGS 8
 #define LINE_LEN 256
 
+/* Set by "quit" (or stdin EOF) so ai_agent_main can detect the CLI has
+ * finished. Deliberately separate from g_shutdown_requested: quitting the
+ * interactive CLI of a second (config-only) instance must NOT tear down the
+ * boot-time background agent. */
+static volatile bool s_cli_done = false;
+
+bool nsh_cli_done(void)
+{
+    return s_cli_done;
+}
+
 /* ── Helpers ──────────────────────────────────────────────────── */
 
 static int tokenise(char* line, char** argv, int max_argc)
@@ -96,6 +107,7 @@ static void cmd_help(void)
         "  set_feishu_app <app_id> <app_secret>  - Set Feishu app credentials\n"
         "  set_feishu_user_token <token>  - Set Feishu user_access_token for doc APIs\n"
         "  set_llm <preset|host> [model] [key] - Switch LLM backend (kimi/qwen/deepseek/glm/openai)\n"
+        "  thinking <on|off>      - Toggle MiMo thinking mode (off = faster replies)\n"
         "  set_vision_llm <preset|host> [model] [key] - Set independent vision model\n"
         "  list_models [--free] [keyword] - List available models (openrouter)\n"
         "  memory_read          - Read MEMORY.md\n"
@@ -136,6 +148,7 @@ static void cmd_help(void)
         "  voice_test_asr <file>  - Test ASR recognition\n"
         "  set_voice_tts <name>   - Switch TTS backend\n"
         "  set_voice_asr <name>   - Switch ASR backend\n"
+        "  speak <text>           - Read text aloud through the speaker\n"
         "  set_weixin_token <tok> - Set WeChat bot token\n"
         "  weixin_login           - QR code login to WeChat\n"
         "  router_status          - Show LLM router status\n"
@@ -307,9 +320,8 @@ static void cmd_session_clear_all(void)
 
 static void cmd_heap_info(void)
 {
-    struct mallinfo mi = mallinfo();
-    printf("Heap: arena=%d fordblks(free)=%d uordblks(used)=%d\n",
-        mi.arena, mi.fordblks, mi.uordblks);
+    /* mallinfo() is unsafe on this board — skip */
+    printf("Heap info: not available (mallinfo disabled)\n");
 }
 
 static void cmd_set_proxy(int argc, char** argv)
@@ -466,6 +478,7 @@ static void cmd_config_show(void)
     SHOW_CFG("Model", AGENT_CFG_KEY_MODEL, false);
     SHOW_CFG("LLM Host", AGENT_CFG_KEY_LLM_HOST, false);
     SHOW_CFG("LLM Path", AGENT_CFG_KEY_LLM_PATH, false);
+    SHOW_CFG("Thinking", AGENT_CFG_KEY_LLM_THINKING, false);
     SHOW_CFG("Vision Model", AGENT_CFG_KEY_VISION_MODEL, false);
     SHOW_CFG("Vision Host", AGENT_CFG_KEY_VISION_HOST, false);
     SHOW_CFG("Vision Key", AGENT_CFG_KEY_VISION_API_KEY, true);
@@ -505,6 +518,33 @@ static void cmd_config_reset(void)
 {
     config_erase_all();
     printf("All runtime config cleared. Build-time defaults will be used on restart.\n");
+}
+
+static void cmd_thinking(int argc, char** argv)
+{
+    if (argc < 2) {
+        char val[16] = { 0 };
+        if (claw_config_get(AGENT_CFG_KEY_LLM_THINKING, val, sizeof(val)) == OK && val[0])
+            printf("LLM thinking: %s\n", val);
+        else
+            printf("LLM thinking: on (default)\n");
+        return;
+    }
+
+    int disabled;
+    if (strcmp(argv[1], "off") == 0 || strcmp(argv[1], "disabled") == 0 ||
+        strcmp(argv[1], "0") == 0)
+        disabled = 1;
+    else if (strcmp(argv[1], "on") == 0 || strcmp(argv[1], "enabled") == 0 ||
+        strcmp(argv[1], "1") == 0)
+        disabled = 0;
+    else {
+        printf("Usage: thinking <on|off>\n");
+        return;
+    }
+
+    llm_set_thinking(disabled);
+    printf("LLM thinking %s\n", disabled ? "OFF (fast)" : "ON (default)");
 }
 
 #ifdef CONFIG_AI_AGENT_BLE_GATT
@@ -659,9 +699,11 @@ static void cmd_claw_test(int argc, char** argv)
 
 static void cmd_quit(void)
 {
-    printf("Exiting agent...\n");
+    printf("Exiting CLI...\n");
     fflush(stdout);
-    agent_request_shutdown();
+    /* Signal the CLI is done. This only ends the interactive CLI loop; the
+     * boot-time background agent keeps running (see nsh_cli_done). */
+    s_cli_done = true;
 }
 
 static void cmd_launch_app(int argc, char** argv)
@@ -882,6 +924,8 @@ static void* cli_thread(void* arg)
     char line[LINE_LEN];
     char* argv[MAX_ARGS];
 
+    s_cli_done = false;
+
     syslog(LOG_INFO, "[%s] NSH CLI started. Type 'help' for commands.\n", TAG);
     pthread_mutex_lock(&g_stdout_lock);
     printf("vela> ");
@@ -925,6 +969,8 @@ static void* cli_thread(void* arg)
             cmd_set_feishu_user_token(argc, argv);
         else if (strcmp(cmd, "set_llm") == 0)
             cmd_set_llm(argc, argv);
+        else if (strcmp(cmd, "thinking") == 0)
+            cmd_thinking(argc, argv);
         else if (strcmp(cmd, "set_vision_llm") == 0)
             cmd_set_vision_llm(argc, argv);
         else if (strcmp(cmd, "list_models") == 0)
@@ -1010,6 +1056,8 @@ static void* cli_thread(void* arg)
             cmd_set_voice_tts(argc, argv);
         else if (strcmp(cmd, "set_voice_asr") == 0)
             cmd_set_voice_asr(argc, argv);
+        else if (strcmp(cmd, "speak") == 0)
+            cmd_speak(argc, argv);
         else if (strcmp(cmd, "set_weixin_token") == 0)
             cmd_set_weixin_token(argc, argv);
         else if (strcmp(cmd, "weixin_login") == 0)
@@ -1069,6 +1117,7 @@ static void* cli_thread(void* arg)
         pthread_mutex_unlock(&g_stdout_lock);
     }
 
+    s_cli_done = true;
     syslog(LOG_INFO, "[%s] CLI thread exiting\n", TAG);
     return NULL;
 }
@@ -1086,5 +1135,9 @@ int nsh_commands_init(void)
 
 int nsh_commands_start(void)
 {
+    /* Reset synchronously (before the thread runs) so a caller that polls
+     * nsh_cli_done() right after start doesn't observe a stale "true" from
+     * a previous CLI session and bail out early. */
+    s_cli_done = false;
     return agent_task_create(cli_thread, "agent_cli", AGENT_CLI_STACK, NULL, AGENT_CLI_PRIO);
 }

--- a/src/channels/nsh_commands.h
+++ b/src/channels/nsh_commands.h
@@ -40,3 +40,10 @@ int nsh_commands_init(void);
  * Call after all services are in a known state (post Phase 5).
  */
 int nsh_commands_start(void);
+
+/**
+ * True once the CLI thread has exited (user typed "quit" or stdin hit EOF).
+ * Used by ai_agent_main so a CLI-only second instance can return to NSH
+ * without triggering a full agent shutdown.
+ */
+bool nsh_cli_done(void);

--- a/src/ui/lvgl_ui_channel.c
+++ b/src/ui/lvgl_ui_channel.c
@@ -547,6 +547,28 @@ void lvgl_ui_channel_show(void)
     lv_async_call(show_screen_async_cb, NULL);
 }
 
+/* Run TTS on a worker thread. voice_channel_speak() does blocking network
+ * round-trips (and several of them for a long story), so calling it inline
+ * would stall the dispatch thread and leave the UI unresponsive — frozen
+ * touch, screen not refreshing. A detached thread keeps the UI alive and
+ * relies on voice_channel_speak()'s internal abort logic to cancel an
+ * in-flight utterance when a newer one arrives. */
+static void* tts_speak_thread(void* arg)
+{
+    char* text = (char*)arg;
+
+    if (text) {
+        int ret = voice_channel_speak(text);
+        if (ret != 0) {
+            syslog(LOG_ERR, "[%s] voice_channel_speak failed (rc=%d)\n",
+                TAG, ret);
+        }
+        free(text);
+    }
+
+    return NULL;
+}
+
 int lvgl_ui_channel_send(const char* text)
 {
     int ret;
@@ -587,10 +609,26 @@ int lvgl_ui_channel_send(const char* text)
 
     lv_async_call(chat_view_add_message_async_cb, payload);
 
-    /* TTS is blocking — run after scheduling the UI update */
-    ret = voice_channel_speak(text);
+    /* TTS is blocking — run it on a worker thread after scheduling the UI
+     * update so the dispatch thread returns immediately. */
+    char* tts_text = malloc(strlen(text) + 1);
+    if (!tts_text) {
+        syslog(LOG_ERR, "[%s] TTS text alloc failed\n", TAG);
+        return 0;
+    }
+
+    strcpy(tts_text, text);
+
+    pthread_t tid;
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    ret = pthread_create(&tid, &attr, tts_speak_thread, tts_text);
+    pthread_attr_destroy(&attr);
+
     if (ret != 0) {
-        syslog(LOG_ERR, "[%s] voice_channel_speak failed (rc=%d)\n", TAG, ret);
+        free(tts_text);
+        syslog(LOG_ERR, "[%s] TTS thread spawn failed (rc=%d)\n", TAG, ret);
     }
 
     return 0;


### PR DESCRIPTION
- agent_main: a second foreground 'ai_agent' (started manually to reach set_wifi / set_llm) no longer re-runs init. In a FLAT build the statics are shared, so the boot-time instance was being torn down and two outbound dispatchers fought over the message bus.
- nsh_commands: 'quit' uses nsh_cli_done() instead of agent_request_shutdown(), so leaving the config CLI does not kill the boot-time daemon
- mqtt_channel: parent-side channel and child-confirmation reporting
- lvgl_ui_channel / cmd_voice: display and voice-command wiring

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
